### PR TITLE
Auto-resolve defaultMeasureId in add_serving when caller passes None/0

### DIFF
--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -387,6 +387,32 @@ class CronometerClient:
         if diary_group == 0:
             diary_group = _meal_group_for_hour(now.hour)
 
+        # Cronometer's backend rejects measureId=0 for database foods
+        # (CRDB / NCCDB / FDC-branded) with a misleading
+        # 'JSONObject["userId"] is not a int (Null)' error. The official
+        # Android client always sends a real measureId; only user-created
+        # custom foods accept measureId=0 / gram-mode logging. When the
+        # caller does not specify a measure, look up the food's
+        # defaultMeasureId via get_food and substitute it so the request
+        # matches what the app would send.
+        if not measure_id:
+            try:
+                food = self.get_food(food_id)
+                default_id = food.get("defaultMeasureId")
+                if default_id:
+                    measure_id = default_id
+                    logger.debug(
+                        "add_serving: using defaultMeasureId=%s for food_id=%s",
+                        default_id,
+                        food_id,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "add_serving: defaultMeasureId lookup failed (%s); "
+                    "continuing with measureId=0",
+                    exc,
+                )
+
         serving = {
             "order": (diary_group << 16) | 1,
             "day": day_str,


### PR DESCRIPTION
## Summary

- Closes #4.
- When `add_serving` is called with `measure_id=0` or `None`, look up the food via `get_food()` and substitute its `defaultMeasureId` before building the serving payload.
- Strictly additive: if `get_food` fails for any reason, the previous behaviour (`measureId=0`) is preserved and a warning is logged.

## Why

`add_serving(measure_id=0, ...)` works for user-created custom foods but is rejected for every CRDB / NCCDB / FDC-branded food with this very misleading error:

\`\`\`json
{\"result\":\"FAIL\",
 \"error\":\"JSONObject[\\\"userId\\\"] is not a int (Null).\"}
\`\`\`

The error blames `userId`, but the actual offender is `measureId=0`. The official Android client never sends 0 for database foods -- it always pulls a real measureId from the food's `measures` array. This change makes the Python client behave the same way.

## Test plan

- [x] CRDB food (Kaiku ÑAM Choco, id `50136743`) with `measure_id=None` → resolves to `defaultMeasureId=90510267` (ml) and the serving is logged successfully.
- [x] Custom food (no `defaultMeasureId`) → falls through with `measureId=0`, logging still works (existing path unchanged).
- [x] Caller passes an explicit `measure_id` → no extra `get_food` call is made, behaviour is unchanged.

## Notes

- One extra `/api/v2/get_food` round-trip is incurred only on the implicit-measure path. Callers that already know the measure pay nothing extra.
- The lookup failure path keeps the previous failure mode rather than raising, so this is a strict superset of today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)