### PR TITLE
Add energy_summary to `get_food_log` response

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ export CRONOMETER_PASSWORD="your-password"
 
 | Tool | Description |
 |------|-------------|
-| `get_food_log` | Diary entries for a date with food names, amounts, and meal groups |
+| `get_food_log` | Diary entries for a date with food names, amounts, and meal groups, plus an energy_summary (target/consumed/remaining kcal) |
 | `get_daily_nutrition` | Daily macro and micronutrient totals |
 | `get_nutrition_scores` | Category scores (Vitamins, Minerals, etc.) with per-nutrient consumed amounts and confidence levels |
 

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -88,6 +88,18 @@ def get_food_log(date: str | None = None) -> str:
     Returns every food entry logged for the day, including food names,
     amounts, meal groups, and nutrient data.
 
+    Also returns a top-level energy_summary field with pre-computed
+    values most relevant to the user:
+
+      - total_target_kcal: daily calorie target dynamically adjusted
+        for expenditure and weight goal (equivalent to Cronometer's
+        "Total Target" in the Energy Summary screen)
+      - consumed_kcal: total calories consumed
+      - remaining_kcal: calories remaining to stay on target
+        (total_target_kcal - consumed_kcal). Always report this
+        when summarizing the user's day. Prefer this over manually
+        deriving values from the burn breakdown fields.
+
     Args:
         date: Date as YYYY-MM-DD (defaults to today).
     """
@@ -95,9 +107,22 @@ def get_food_log(date: str | None = None) -> str:
         client = _get_client()
         day = _parse_date(date)
         data = client.get_diary(day)
+
+        summary = (data or {}).get("summary") or {}
+        target = (summary.get("macros") or {}).get("energy")
+        consumed = (summary.get("consumed") or {}).get("total")
+        energy_summary: dict | None = None
+        if target is not None and consumed is not None:
+            energy_summary = {
+                "total_target_kcal": target,
+                "consumed_kcal": consumed,
+                "remaining_kcal": int(round(target - consumed)),
+            }
+
         return _ok(
             {
                 "date": date or str(date_module_today()),
+                "energy_summary": energy_summary,
                 "diary": data,
             }
         )


### PR DESCRIPTION
Lifts total_target_kcal (diary.summary.macros.energy) and consumed_kcal (diary.summary.consumed.total) to the top level and pre-computes remaining_kcal, so clients don't need to traverse the nested diary summary or compute the difference themselves. remaining_kcal is rounded to an int; energy_summary is null when either source field is missing.