### PR TITLE
Add saturated_fat_g to add_custom_food

### DIFF
--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -307,6 +307,7 @@ class CronometerClient:
         fiber_g: float = 0,
         sugar_g: float = 0,
         sodium_mg: float = 0,
+        saturated_fat_g: float = 0,
         serving_name: str = "1 serving",
         serving_grams: float = 100.0,
     ) -> dict:
@@ -331,6 +332,7 @@ class CronometerClient:
             {"id": NUTRIENT_IDS["fiber"], "amount": round(fiber_g * scale, 2)},
             {"id": NUTRIENT_IDS["sugar"], "amount": round(sugar_g * scale, 2)},
             {"id": NUTRIENT_IDS["sodium"], "amount": round(sodium_mg * scale, 2)},
+            {"id": NUTRIENT_IDS["saturated_fat"], "amount": round(saturated_fat_g * scale, 2)},
             # Derived / calculated fields the app includes
             {"id": -203, "amount": round(protein_g * scale, 2)},
             {"id": -204, "amount": round(fat_g * scale, 2)},

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -332,7 +332,10 @@ class CronometerClient:
             {"id": NUTRIENT_IDS["fiber"], "amount": round(fiber_g * scale, 2)},
             {"id": NUTRIENT_IDS["sugar"], "amount": round(sugar_g * scale, 2)},
             {"id": NUTRIENT_IDS["sodium"], "amount": round(sodium_mg * scale, 2)},
-            {"id": NUTRIENT_IDS["saturated_fat"], "amount": round(saturated_fat_g * scale, 2)},
+            {
+                "id": NUTRIENT_IDS["saturated_fat"],
+                "amount": round(saturated_fat_g * scale, 2),
+            },
             # Derived / calculated fields the app includes
             {"id": -203, "amount": round(protein_g * scale, 2)},
             {"id": -204, "amount": round(fat_g * scale, 2)},

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -517,6 +517,7 @@ def add_custom_food(
     fiber_g: float = 0,
     sugar_g: float = 0,
     sodium_mg: float = 0,
+    saturated_fat_g: float = 0,
     serving_name: str = "1 serving",
     serving_grams: float = 100.0,
 ) -> str:
@@ -534,6 +535,7 @@ def add_custom_food(
         fiber_g: Fiber per serving (g, default 0).
         sugar_g: Sugar per serving (g, default 0).
         sodium_mg: Sodium per serving (mg, default 0).
+        saturated_fat_g: Saturated fat per serving (g, default 0).
         serving_name: Name for the serving size (default "1 serving").
         serving_grams: Weight of one serving in grams (default 100).
     """
@@ -548,6 +550,7 @@ def add_custom_food(
             fiber_g=fiber_g,
             sugar_g=sugar_g,
             sodium_mg=sodium_mg,
+            saturated_fat_g=saturated_fat_g,
             serving_name=serving_name,
             serving_grams=serving_grams,
         )


### PR DESCRIPTION
Custom foods could not include saturated fat — the field had no parameter, so foods created via the API silently undercounted daily saturated fat totals (now surfaced in summaries since #14).

Adds saturated_fat_g (per-serving, g, default 0) to add_custom_food, wired to nutrient ID 606 with the same per-100g scaling as other nutrients. Backward compatible — existing calls are unaffected.

Field-tested for 3 weeks as a local patch driving a personal food library with cardiovascular-target tracking.

The same pattern extends naturally to cholesterol, trans_fat, and omega_3/6 (already in NUTRIENT_IDS) if there's interest in a follow-up.

(Follow-up from #13 — thanks for the fast turnaround on that one!)