### PR TITLE
Add biometrics support (weight, body fat, and other tracked metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Unlike [cronometer-mcp](https://github.com/cphoskins/cronometer-mcp), which take
 - **Custom foods** -- create foods with custom nutrition data
 - **Macro targets** -- read weekly schedule and saved templates
 - **Fasting** -- view history and aggregate statistics
+- **Biometrics** -- weight, body fat, heart rate, and other tracked metrics over a date range
 
 ## Quick Start
 
@@ -112,6 +113,8 @@ export CRONOMETER_PASSWORD="your-password"
 | `get_macro_targets` | Weekly macro schedule and saved target templates |
 | `get_fasting_history` | Fasting history within a date range |
 | `get_fasting_stats` | Aggregate fasting statistics |
+| `list_biometrics` | List trackable biometric metrics and their units |
+| `get_biometrics` | Biometric time series (e.g. weight, body fat) within a date range |
 
 All date parameters use `YYYY-MM-DD` format and default to today when omitted.
 
@@ -186,7 +189,7 @@ This server communicates with `mobile.cronometer.com` -- the same REST API used 
 
 The API uses two protocols:
 
-- **v2 (`POST /api/v2/*`)** -- JSON-body auth, used for most operations (food search, diary read/write, nutrition, fasting, macros)
+- **v2 (`POST /api/v2/*`)** -- JSON-body auth, used for most operations (food search, diary read/write, nutrition, fasting, macros, biometrics)
 - **v3 (`DELETE /api/v3/user/{id}/*`)** -- Header-based auth (`x-crono-session`), used for diary entry deletion
 
 ## Python API

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -871,6 +871,66 @@ class CronometerClient:
         logger.info("Fetched fasting stats")
         return data
 
+    # ------------------------------------------------------------------
+    # Biometrics
+    # ------------------------------------------------------------------
+
+    def get_metrics(self) -> list[dict]:
+        """Get the biometric metric catalog.
+
+        Each metric describes one trackable biometric (Weight, Body Fat,
+        Heart Rate, Blood Glucose, Waist Size, ...) with keys: id, name,
+        legacy (bool), and units -- a list of {id, name, ...} the value can
+        be expressed in. Cronometer stores every biometric under one of
+        these metric IDs.
+
+        Uses: POST /api/v2/get_metrics
+        """
+        payload = {"config": {"call_version": 1}}
+        data = self._request("/api/v2/get_metrics", payload)
+        return data.get("metrics", [])
+
+    def get_biometrics(
+        self,
+        metric_id: int,
+        unit_id: int,
+        start: date | None = None,
+        end: date | None = None,
+    ) -> dict:
+        """Get a biometric time series (e.g. weight, body fat) over a range.
+
+        Args:
+            metric_id: Metric ID from get_metrics (e.g. 1 for Weight).
+            unit_id: Unit ID from the metric's units list (e.g. 1 for kg).
+            start: Start date. Defaults to 30 days before `end`.
+            end: End date. Defaults to today.
+
+        Uses: POST /api/v2/get_biometrics
+
+        Returns the API response: {"data": [{"day": "YYYY-MM-DD", "value": float}, ...]}.
+        """
+        from datetime import timedelta
+
+        end = end or date.today()
+        start = start or (end - timedelta(days=30))
+
+        payload = {
+            "metricId": metric_id,
+            "unitId": unit_id,
+            "start": self._format_day(start),
+            "end": self._format_day(end),
+            "config": {"call_version": 1},
+        }
+        data = self._request("/api/v2/get_biometrics", payload)
+        logger.info(
+            "Fetched biometrics for metric %d (unit %d) %s to %s",
+            metric_id,
+            unit_id,
+            self._format_day(start),
+            self._format_day(end),
+        )
+        return data
+
 
 # ======================================================================
 # Helpers

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -669,6 +669,99 @@ def get_fasting_stats() -> str:
 
 
 # ------------------------------------------------------------------
+# Biometrics
+# ------------------------------------------------------------------
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+)
+def list_biometrics() -> str:
+    """List the biometric metrics tracked in Cronometer.
+
+    Returns every metric type the account can record (Weight, Body Fat,
+    Heart Rate, Blood Glucose, Waist Size, Sleep, blood panels, body
+    measurements, etc.). Use the metric_id and a unit_id from the results
+    with get_biometrics.
+    """
+    try:
+        client = _get_client()
+        metrics = client.get_metrics()
+
+        # Slim down results to the fields needed to call get_biometrics
+        results = []
+        for m in metrics:
+            results.append(
+                {
+                    "metric_id": m.get("id"),
+                    "name": m.get("name"),
+                    "units": [
+                        {"unit_id": u.get("id"), "name": u.get("name")}
+                        for u in m.get("units", [])
+                    ],
+                }
+            )
+
+        return _ok({"count": len(results), "metrics": results})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+)
+def get_biometrics(
+    metric_id: int,
+    unit_id: int,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """Get a biometric time series such as weight or body fat from Cronometer.
+
+    Returns the recorded values over the date range as a list of
+    {day, value} points.
+
+    Use list_biometrics to find metric_id and unit_id (e.g. Weight is
+    metric_id 1, with unit_id 1 for kg or 2 for lbs).
+
+    Args:
+        metric_id: Numeric metric ID from list_biometrics.
+        unit_id: Numeric unit ID from the metric's units in list_biometrics.
+        start_date: Start date as YYYY-MM-DD (defaults to 30 days ago).
+        end_date: End date as YYYY-MM-DD (defaults to today).
+    """
+    try:
+        client = _get_client()
+        data = client.get_biometrics(
+            metric_id,
+            unit_id,
+            start=_parse_date(start_date),
+            end=_parse_date(end_date),
+        )
+        return _ok(
+            {
+                "metric_id": metric_id,
+                "unit_id": unit_id,
+                "start_date": start_date or str(date.today() - timedelta(days=30)),
+                "end_date": end_date or str(date.today()),
+                "biometrics": data,
+            }
+        )
+    except Exception as e:
+        return _err(e)
+
+
+# ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds read access to Cronometer biometric time series — weight, body fat, heart rate, blood glucose, body measurements, blood panels, etc.

Two mobile API endpoints have been reverse-engineered and mapped:
- `POST /api/v2/get_metrics` — the metric catalogue (54 metrics), each with its available units and unit IDs.
- `POST /api/v2/get_biometrics` — `{metricId, unitId, start, end}` → `{"data": [{"day", "value"}]}` time series.

## Changes
- **`client.py`** — `get_metrics()` and `get_biometrics(metric_id, unit_id, start, end)`.
- **`server.py`** — two read-only MCP tools:
  - `list_biometrics` — discover the available metrics; returns each metric's `metric_id`, name, and unit IDs.
  - `get_biometrics` — the time series; defaults to the last 30 days.
- **`README.md`** — documents the new tools and the two endpoints.

## Testing
The functionality has been tested against my live account: 
  - weight series in kg
  - body fat percentage
  - skeletal muscle mass

`ruff check` and `ruff format --check` both pass.