### PR TITLE
Handle result:"FAIL" as an auth failure and retry login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,3 +22,6 @@ jobs:
 
       - name: Check formatting with ruff
         run: uv run ruff format --check
+
+      - name: Run tests
+        run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ cronometer-api-mcp = "cronometer_api_mcp.server:main"
 [dependency-groups]
 dev = [
     "ruff>=0.8.0",
+    "pytest>=8.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -259,11 +259,13 @@ class CronometerClient:
         resp.raise_for_status()
         data = resp.json()
 
-        # Some endpoints return errors in the body
-        if isinstance(data, dict) and data.get("result") == "FAILURE":
+        # Some endpoints return errors in the body with an HTTP 200. An expired
+        # session comes back as {"result": "FAIL", "error": "..."}; "FAILURE" is
+        # kept defensively (never observed in real traffic, but harmless).
+        if isinstance(data, dict) and data.get("result") in ("FAIL", "FAILURE"):
             if not _retried:
                 logger.warning("Cronometer request failed, re-authenticating: %s", data)
-                self._token = None
+                self._invalidate_session()
                 self.login()
                 return self._request(endpoint, payload, _retried=True)
             raise CronometerError(f"Cronometer API error: {data}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,123 @@
+"""Regression tests for CronometerClient auth-failure handling.
+
+Covers issue #18: an expired session comes back as an HTTP 200 body of
+{"result": "FAIL", ...} which the client previously failed to detect
+(it only matched "FAILURE"), so a stale token was never invalidated and
+the failure was surfaced to callers as a success.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cronometer_api_mcp.client import CronometerClient, CronometerError
+
+# Real captured response body from an expired session (see repo `flows`).
+REAL_FAIL_BODY = {"result": "FAIL", "error": "Token Authorization failed"}
+# Synthetic/defensive variant. Never observed in real traffic, but the
+# client keeps handling it just in case some endpoint uses it.
+SYNTHETIC_FAILURE_BODY = {"result": "FAILURE", "error": "synthetic"}
+
+
+class FakeResp:
+    def __init__(self, body, status: int = 200) -> None:
+        self._body = body
+        self.status_code = status
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def json(self):
+        return self._body
+
+
+def make_client(tmp_path: Path, responses: list[dict]):
+    """Build a client whose HTTP POST returns `responses` in order and whose
+    login() just swaps in a fresh token without hitting the network.
+
+    Returns (client, state) where state tracks login/post call counts.
+    """
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "STALE_TOKEN"
+
+    state = {"login": 0, "post": 0}
+
+    def fake_login() -> None:
+        state["login"] += 1
+        client._user_id = 123
+        client._token = f"FRESH_TOKEN_{state['login']}"
+
+    def fake_post(endpoint, json=None):
+        idx = state["post"]
+        state["post"] += 1
+        body = responses[min(idx, len(responses) - 1)]
+        return FakeResp(body)
+
+    client.login = fake_login  # type: ignore[method-assign]
+    client._http.post = fake_post  # type: ignore[method-assign]
+    return client, state
+
+
+def test_fail_invalidates_token_logs_in_and_retries_once(tmp_path):
+    """HTTP 200 + result:"FAIL" -> invalidate token, login, retry once, succeed."""
+    client, state = make_client(
+        tmp_path, [REAL_FAIL_BODY, {"result": "SUCCESS", "id": 999}]
+    )
+
+    result = client._request("/api/v2/get_diary", {})
+
+    assert result == {"result": "SUCCESS", "id": 999}
+    assert state["login"] == 1
+    assert state["post"] == 2
+
+
+def test_failure_variant_still_retries(tmp_path):
+    """HTTP 200 + result:"FAILURE" retains the original retry behavior."""
+    client, state = make_client(
+        tmp_path, [SYNTHETIC_FAILURE_BODY, {"result": "SUCCESS", "id": 1}]
+    )
+
+    result = client._request("/api/v2/get_diary", {})
+
+    assert result == {"result": "SUCCESS", "id": 1}
+    assert state["login"] == 1
+    assert state["post"] == 2
+
+
+def test_second_failure_raises(tmp_path):
+    """A second failed response raises CronometerError rather than returning it."""
+    client, state = make_client(tmp_path, [REAL_FAIL_BODY, REAL_FAIL_BODY])
+
+    with pytest.raises(CronometerError):
+        client._request("/api/v2/get_diary", {})
+
+    assert state["login"] == 1
+    assert state["post"] == 2
+
+
+def test_add_serving_does_not_return_success_wrapper_on_failure(tmp_path):
+    """add_serving must not surface an API failure body as a success result."""
+    client, state = make_client(tmp_path, [REAL_FAIL_BODY, REAL_FAIL_BODY])
+
+    with pytest.raises(CronometerError):
+        client.add_serving(food_id=1, measure_id=0, grams=100.0)
+
+    assert state["post"] == 2
+
+
+def test_stale_cache_file_is_removed_on_failure(tmp_path):
+    """The stale cached session file is deleted when a FAIL is detected."""
+    session_path = tmp_path / "session.json"
+    session_path.write_text('{"username": "", "user_id": 123, "token": "STALE"}')
+
+    client, _ = make_client(tmp_path, [REAL_FAIL_BODY, {"result": "SUCCESS", "id": 5}])
+    # make_client overwrote session_path arg via same tmp_path
+    assert client._session_path == session_path
+
+    client._request("/api/v2/get_diary", {})
+
+    # _invalidate_session() should have unlinked the stale file.
+    assert not session_path.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -118,7 +119,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.8.0" }]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
+]
 
 [[package]]
 name = "cryptography"
@@ -234,6 +238,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -283,6 +296,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -363,6 +394,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -374,6 +414,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cronometer returns an expired session as an HTTP 200 body of {"result":"FAIL","error":"..."}, but _request() only matched "FAILURE" (never observed in real traffic) so the stale token was returned to callers as a success. Match both "FAIL" and "FAILURE", and invalidate the cached session on disk before re-logging in so the bad token does not persist.

Add regression tests for the retry-once-then-raise behavior.

Closes #18