### PR TITLE
Enrich get_food_log entries with food names and per-serving nutrients

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export CRONOMETER_PASSWORD="your-password"
 
 | Tool | Description |
 |------|-------------|
-| `get_food_log` | Diary entries for a date with food names, amounts, and meal groups, plus an energy_summary (target/consumed/remaining kcal) and a nutrition_summary of consumed totals for every tracked nutrient |
+| `get_food_log` | Diary entries for a date, each enriched with food name, source, serving measure/count, and that food's per-entry nutrient contribution, plus an energy_summary (target/consumed/remaining kcal) and a nutrition_summary of consumed totals for every tracked nutrient |
 | `get_daily_nutrition` | Consumed macro and micronutrient totals for every nutrient tracked in Cronometer |
 | `get_nutrition_scores` | Category scores (Vitamins, Minerals, etc.) with per-nutrient consumed amounts and confidence levels |
 

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -374,6 +374,24 @@ class CronometerClient:
         )
         return data
 
+    def get_foods(self, food_ids: list[int]) -> list[dict]:
+        """Batch-fetch full food details for many food IDs in one call.
+
+        Mirrors get_food but resolves a list of IDs at once, which is how the
+        Cronometer app resolves an entire day's diary. Returns a list of food
+        objects, each with keys: id, name, source, measures, defaultMeasureId,
+        nutrients, etc. Nutrient amounts are stored per-100g.
+
+        Returns an empty list if food_ids is empty.
+        """
+        if not food_ids:
+            return []
+        payload = {"ids": list(food_ids), "config": {"call_version": 1}}
+        data = self._request("/api/v2/get_foods", payload)
+        foods = data.get("foods", []) if isinstance(data, dict) else []
+        logger.info("Batch-fetched %d/%d foods", len(foods), len(food_ids))
+        return foods
+
     # ------------------------------------------------------------------
     # Custom food creation
     # ------------------------------------------------------------------
@@ -809,6 +827,114 @@ class CronometerClient:
             len(nutrients),
         )
         return {"macros": macros, "nutrients": nutrients}
+
+    def enrich_diary_servings(self, diary: dict) -> dict:
+        """Merge food metadata into a raw get_diary payload (best-effort).
+
+        Diary "Serving" entries carry only numeric IDs (foodId, measureId,
+        grams). This resolves each foodId via a single batch get_foods call and
+        merges per-entry:
+
+          - name, source, category: from the food object
+          - measure: {measure_id, name, grams_per_unit} for the entry's
+            measureId (falls back to the food's defaultMeasureId)
+          - servings: grams / grams_per_unit, when derivable
+          - nutrients: the food's per-100g profile scaled to the entry's grams,
+            labeled with name/unit/category via the nutrient definitions catalog
+
+        Enrichment is best-effort: if the get_foods call fails or a food is not
+        returned, the corresponding entries are left unchanged. The diary dict
+        is mutated in place and also returned. Non-Serving entries (Exercise,
+        Biometric) already carry a name and are left untouched.
+        """
+        if not isinstance(diary, dict):
+            return diary
+        entries = diary.get("diary")
+        if not isinstance(entries, list):
+            return diary
+
+        food_ids = sorted(
+            {
+                e["foodId"]
+                for e in entries
+                if isinstance(e, dict)
+                and e.get("type") == "Serving"
+                and isinstance(e.get("foodId"), int)
+            }
+        )
+        if not food_ids:
+            return diary
+
+        try:
+            foods = self.get_foods(food_ids)
+        except Exception as exc:  # best-effort: keep diary without names
+            logger.warning("Diary enrichment skipped (get_foods failed): %s", exc)
+            return diary
+
+        food_by_id = {f.get("id"): f for f in foods if isinstance(f, dict)}
+        try:
+            defs = self.get_nutrient_definitions()
+        except Exception:
+            defs = {}
+
+        for entry in entries:
+            if not isinstance(entry, dict) or entry.get("type") != "Serving":
+                continue
+            food = food_by_id.get(entry.get("foodId"))
+            if not food:
+                continue
+
+            entry["name"] = food.get("name")
+            entry["source"] = food.get("source")
+            if food.get("category") is not None:
+                entry["category"] = food.get("category")
+
+            measures = {
+                m.get("id"): m for m in food.get("measures", []) if isinstance(m, dict)
+            }
+            measure = measures.get(entry.get("measureId")) or measures.get(
+                food.get("defaultMeasureId")
+            )
+            grams = entry.get("grams")
+            if measure:
+                grams_per_unit = measure.get("value")
+                entry["measure"] = {
+                    "measure_id": measure.get("id"),
+                    "name": measure.get("name"),
+                    "grams_per_unit": grams_per_unit,
+                }
+                if (
+                    isinstance(grams, (int, float))
+                    and isinstance(grams_per_unit, (int, float))
+                    and grams_per_unit
+                ):
+                    entry["servings"] = round(grams / grams_per_unit, 4)
+
+            # Food nutrients are stored per-100g; scale to the entry's grams.
+            if isinstance(grams, (int, float)):
+                scale = grams / 100.0
+                scaled: list[dict] = []
+                for n in food.get("nutrients", []):
+                    if not isinstance(n, dict):
+                        continue
+                    nid = n.get("id")
+                    amount = n.get("amount")
+                    if nid is None or not isinstance(amount, (int, float)):
+                        continue
+                    meta = defs.get(nid, {})
+                    scaled.append(
+                        {
+                            "id": nid,
+                            "name": meta.get("name"),
+                            "amount": round(amount * scale, 4),
+                            "unit": meta.get("unit"),
+                            "category": meta.get("category"),
+                        }
+                    )
+                entry["nutrients"] = scaled
+
+        logger.info("Enriched %d diary foods with names/nutrients", len(food_by_id))
+        return diary
 
     # ------------------------------------------------------------------
     # Macro targets

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -84,8 +84,14 @@ def _err(e: Exception) -> str:
 def get_food_log(date: str | None = None) -> str:
     """Get all diary entries for a given date.
 
-    Returns every food entry logged for the day, including food names,
-    amounts, meal groups, and nutrient data.
+    Returns every food entry logged for the day. Each "Serving" entry is
+    enriched (best-effort) with the food's name, source, the serving measure
+    (unit name and grams per unit), the number of servings, and that food's
+    own nutrient profile scaled to the amount eaten. Non-food entries
+    (exercise, biometrics) carry their own name.
+
+    Note: the per-entry "nutrients" are each food's individual contribution,
+    which is distinct from the day-level nutrition_summary aggregate below.
 
     Also returns a top-level energy_summary field with pre-computed
     values most relevant to the user:
@@ -114,6 +120,7 @@ def get_food_log(date: str | None = None) -> str:
         client = _get_client()
         day = _parse_date(date)
         data = client.get_diary(day)
+        data = client.enrich_diary_servings(data)
 
         summary = (data or {}).get("summary") or {}
         target = (summary.get("macros") or {}).get("energy")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ import pytest
 
 from cronometer_api_mcp.client import CronometerClient, CronometerError
 
-# Real captured response body from an expired session (see repo `flows`).
+# Real response body observed from an expired session.
 REAL_FAIL_BODY = {"result": "FAIL", "error": "Token Authorization failed"}
 # Synthetic/defensive variant. Never observed in real traffic, but the
 # client keeps handling it just in case some endpoint uses it.
@@ -121,3 +121,133 @@ def test_stale_cache_file_is_removed_on_failure(tmp_path):
 
     # _invalidate_session() should have unlinked the stale file.
     assert not session_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Diary enrichment (get_food_log food names / per-entry nutrients)
+# ---------------------------------------------------------------------------
+
+
+def _enrich_client(tmp_path: Path):
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "TOKEN"
+    return client
+
+
+SAMPLE_DIARY = {
+    "diary": [
+        {
+            "type": "Serving",
+            "foodId": 100,
+            "measureId": 10,
+            "grams": 200,
+            "order": 65537,
+        },
+        {
+            "type": "Serving",
+            "foodId": 200,
+            "measureId": 999,  # unknown measure -> falls back to default
+            "grams": 50,
+            "order": 65538,
+        },
+        {"type": "Exercise", "name": "Running", "order": 1},
+    ]
+}
+
+SAMPLE_FOODS = [
+    {
+        "id": 100,
+        "name": "Oats",
+        "source": "USDA",
+        "category": "Grains",
+        "defaultMeasureId": 10,
+        "measures": [{"id": 10, "name": "cup", "value": 100.0}],
+        # per-100g
+        "nutrients": [{"id": 208, "amount": 389.0}, {"id": 203, "amount": 16.9}],
+    },
+    {
+        "id": 200,
+        "name": "Milk",
+        "source": "Custom",
+        "defaultMeasureId": 20,
+        "measures": [{"id": 20, "name": "glass", "value": 244.0}],
+        "nutrients": [{"id": 208, "amount": 42.0}],
+    },
+]
+
+NUTRIENT_DEFS = {
+    208: {"name": "Energy", "unit": "kcal", "category": "General"},
+    203: {"name": "Protein", "unit": "g", "category": "Protein"},
+}
+
+
+def test_enrich_diary_merges_names_measures_and_scaled_nutrients(tmp_path):
+    client = _enrich_client(tmp_path)
+    client.get_foods = lambda ids: SAMPLE_FOODS  # type: ignore[method-assign]
+    client.get_nutrient_definitions = lambda: NUTRIENT_DEFS  # type: ignore[method-assign]
+
+    out = client.enrich_diary_servings(
+        {"diary": [dict(e) for e in SAMPLE_DIARY["diary"]]}
+    )
+    entries = out["diary"]
+
+    oats = entries[0]
+    assert oats["name"] == "Oats"
+    assert oats["source"] == "USDA"
+    assert oats["category"] == "Grains"
+    assert oats["measure"] == {
+        "measure_id": 10,
+        "name": "cup",
+        "grams_per_unit": 100.0,
+    }
+    assert oats["servings"] == 2.0  # 200g / 100g per cup
+    # per-100g energy 389 scaled to 200g -> 778
+    energy = next(n for n in oats["nutrients"] if n["id"] == 208)
+    assert energy["amount"] == 778.0
+    assert energy["name"] == "Energy"
+    assert energy["unit"] == "kcal"
+
+    milk = entries[1]
+    # unknown measureId 999 -> fell back to defaultMeasureId 20
+    assert milk["measure"]["measure_id"] == 20
+    assert milk["measure"]["name"] == "glass"
+    # 42 kcal/100g scaled to 50g -> 21
+    assert next(n for n in milk["nutrients"] if n["id"] == 208)["amount"] == 21.0
+
+    # Non-Serving entry untouched
+    assert entries[2] == {"type": "Exercise", "name": "Running", "order": 1}
+
+
+def test_enrich_diary_is_best_effort_when_get_foods_fails(tmp_path):
+    client = _enrich_client(tmp_path)
+
+    def boom(ids):
+        raise CronometerError("network down")
+
+    client.get_foods = boom  # type: ignore[method-assign]
+
+    original = {"diary": [dict(e) for e in SAMPLE_DIARY["diary"]]}
+    out = client.enrich_diary_servings(
+        {"diary": [dict(e) for e in SAMPLE_DIARY["diary"]]}
+    )
+
+    # Entries returned unchanged (no name/nutrients added).
+    assert out["diary"] == original["diary"]
+
+
+def test_enrich_diary_no_servings_skips_lookup(tmp_path):
+    client = _enrich_client(tmp_path)
+    calls = {"n": 0}
+
+    def track(ids):
+        calls["n"] += 1
+        return []
+
+    client.get_foods = track  # type: ignore[method-assign]
+
+    out = client.enrich_diary_servings(
+        {"diary": [{"type": "Exercise", "name": "Running"}]}
+    )
+    assert calls["n"] == 0
+    assert out["diary"] == [{"type": "Exercise", "name": "Running"}]


### PR DESCRIPTION
Diary "Serving" entries only carried numeric IDs (foodId, measureId, grams), so the food log was unreadable without a separate lookup. Resolve every foodId for the day in a single batch get_foods call and merge each food's name, source, serving measure (unit name and grams per unit), serving count, and its nutrient profile scaled to the amount eaten.

Enrichment is best-effort: if get_foods fails the diary is returned unchanged. The per-entry nutrients are each food's individual contribution, distinct from the existing day-level nutrition_summary.