### PR TITLE
Stamp diary entries in the account timezone, not the host clock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "mcp>=1.0.0",
     "httpx[socks]>=0.27.0",
     "python-dotenv>=1.0.0",
+    "tzdata>=2024.1",
 ]
 
 [project.scripts]

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -14,12 +14,17 @@ import logging
 import os
 from datetime import date, datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://mobile.cronometer.com"
+
+# Fallback timezone used only if the account's timezone can't be resolved from
+# the login response. Matches the value historically assumed by this client.
+_DEFAULT_TIMEZONE = "America/New_York"
 
 # Cache the auth token across processes to avoid /api/v2/login rate limits.
 # Cronometer throttles repeated logins per account; reusing a sessionKey lets
@@ -84,6 +89,10 @@ class CronometerClient:
     def __init__(self, *, session_path: Path | None = None) -> None:
         self._user_id: int | None = None
         self._token: str | None = None
+        # IANA timezone name of the Cronometer account, resolved from the login
+        # response (or a restored session cache). Diary timestamps and "today"
+        # are computed in this zone so behavior is independent of the host clock.
+        self._timezone: str | None = None
         self._session_path: Path = session_path or _DEFAULT_SESSION_PATH
         # Cache of nutrient definitions (id -> {name, unit, category}).
         # Definitions are stable for an account, so fetch them once.
@@ -109,10 +118,12 @@ class CronometerClient:
         return os.getenv("CRONOMETER_USERNAME", "")
 
     def _load_cached_session(self) -> None:
-        """Restore (user_id, token) from disk if a cache file exists.
+        """Restore (user_id, token, timezone) from disk if a cache file exists.
 
         Silently ignores any read/parse error: the worst case is we
-        re-login, which is the original behaviour.
+        re-login, which is the original behaviour. A cache written by an
+        older version that predates timezone persistence is treated as
+        invalid so the next login refreshes the account timezone.
         """
         try:
             raw = self._session_path.read_text()
@@ -126,17 +137,24 @@ class CronometerClient:
             return
         token = data.get("token")
         user_id = data.get("user_id")
+        timezone = data.get("timezone")
+        # Reject caches that lack a stored timezone (pre-timezone schema) so we
+        # re-login once and pick up the account zone rather than guessing.
+        if not isinstance(timezone, str):
+            return
         if isinstance(token, str) and isinstance(user_id, int):
             self._user_id = user_id
             self._token = token
+            self._timezone = timezone
             logger.debug(
-                "Restored Cronometer session for user_id=%d from %s",
+                "Restored Cronometer session for user_id=%d (tz=%s) from %s",
                 user_id,
+                timezone,
                 self._session_path,
             )
 
     def _save_cached_session(self) -> None:
-        """Persist (user_id, token) so future processes can reuse it."""
+        """Persist (user_id, token, timezone) so future processes can reuse it."""
         if self._user_id is None or self._token is None:
             return
         try:
@@ -148,6 +166,7 @@ class CronometerClient:
                         "username": self._cache_key(),
                         "user_id": self._user_id,
                         "token": self._token,
+                        "timezone": self._timezone,
                     }
                 )
             )
@@ -162,6 +181,7 @@ class CronometerClient:
     def _invalidate_session(self) -> None:
         """Drop the in-memory token and remove the cache file."""
         self._token = None
+        self._timezone = None
         try:
             self._session_path.unlink()
         except FileNotFoundError:
@@ -213,10 +233,16 @@ class CronometerClient:
 
         self._user_id = data["id"]
         self._token = data["sessionKey"]
+        # The login response embeds the account profile, including the user's
+        # configured IANA timezone. Prefer it over the host clock so diary
+        # timestamps are correct regardless of where the server runs.
+        tz = data.get("timezone")
+        self._timezone = tz if isinstance(tz, str) and tz else _DEFAULT_TIMEZONE
         self._save_cached_session()
         logger.info(
-            "Cronometer login successful (userId=%d, token=%s...)",
+            "Cronometer login successful (userId=%d, tz=%s, token=%s...)",
             self._user_id,
+            self._timezone,
             self._token[:8] if self._token else "???",
         )
 
@@ -322,10 +348,38 @@ class CronometerClient:
     # Date helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _format_day(d: date | None = None) -> str:
-        """Format a date as Cronometer expects: non-zero-padded 'YYYY-M-D'."""
-        d = d or date.today()
+    def _tzinfo(self) -> ZoneInfo:
+        """Return the account's timezone, falling back to the default.
+
+        Resolved from the login response (or restored session cache). If the
+        stored name is unset or unknown (e.g. a zone missing from the system
+        tzdata), log once and fall back so stamping never hard-fails.
+        """
+        name = self._timezone or _DEFAULT_TIMEZONE
+        try:
+            return ZoneInfo(name)
+        except ZoneInfoNotFoundError, ValueError:
+            logger.warning(
+                "Unknown account timezone %r; falling back to %s",
+                name,
+                _DEFAULT_TIMEZONE,
+            )
+            return ZoneInfo(_DEFAULT_TIMEZONE)
+
+    def now(self) -> datetime:
+        """Current wall-clock time in the account's timezone (aware)."""
+        return datetime.now(self._tzinfo())
+
+    def today(self) -> date:
+        """Today's date in the account's timezone."""
+        return self.now().date()
+
+    def _format_day(self, d: date | None = None) -> str:
+        """Format a date as Cronometer expects: non-zero-padded 'YYYY-M-D'.
+
+        Defaults to today in the account's timezone, not the host clock.
+        """
+        d = d or self.today()
         return f"{d.year}-{d.month}-{d.day}"
 
     # ------------------------------------------------------------------
@@ -509,7 +563,7 @@ class CronometerClient:
 
         Returns the serving confirmation dict from the API.
         """
-        now = datetime.now()
+        now = self.now()
         day_str = self._format_day(day)
         time_str = f"{now.hour}:{now.minute}:{now.second}"
 
@@ -663,7 +717,7 @@ class CronometerClient:
         """
         from datetime import timedelta
 
-        to_day = to_day or date.today()
+        to_day = to_day or self.today()
         from_day = from_day or (to_day - timedelta(days=1))
 
         payload = {
@@ -977,7 +1031,7 @@ class CronometerClient:
         """
         from datetime import timedelta
 
-        end = end or date.today()
+        end = end or self.today()
         start = start or (end - timedelta(days=30))
 
         payload = {
@@ -1039,7 +1093,7 @@ class CronometerClient:
         """
         from datetime import timedelta
 
-        end = end or date.today()
+        end = end or self.today()
         start = start or (end - timedelta(days=30))
 
         payload = {

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -643,8 +643,9 @@ def get_fasting_history(
         data = client.get_fasting_with_date_range(start, end)
         return _ok(
             {
-                "start_date": start_date or str(date.today() - timedelta(days=30)),
-                "end_date": end_date or str(date.today()),
+                "start_date": start_date
+                or str(date_module_today() - timedelta(days=30)),
+                "end_date": end_date or str(date_module_today()),
                 "fasting": data,
             }
         )
@@ -758,8 +759,9 @@ def get_biometrics(
             {
                 "metric_id": metric_id,
                 "unit_id": unit_id,
-                "start_date": start_date or str(date.today() - timedelta(days=30)),
-                "end_date": end_date or str(date.today()),
+                "start_date": start_date
+                or str(date_module_today() - timedelta(days=30)),
+                "end_date": end_date or str(date_module_today()),
                 "biometrics": data,
             }
         )
@@ -773,8 +775,13 @@ def get_biometrics(
 
 
 def date_module_today() -> date:
-    """Return today's date (extracted for easy mocking in tests)."""
-    return date.today()
+    """Return today's date in the account's timezone.
+
+    Uses the authenticated client's timezone (resolved from the Cronometer
+    account) so response echoes match the diary day an entry actually lands
+    on, independent of the host clock. Extracted for easy mocking in tests.
+    """
+    return _get_client().today()
 
 
 # ------------------------------------------------------------------

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,188 @@
+"""Timezone-correctness tests for diary stamping (issue #24).
+
+Diary timestamps, auto meal-group, and the default "today" must be derived
+from the account's timezone (resolved from the login response), not the host
+process clock. These tests freeze the process at UTC and assert the client
+still stamps entries in the account zone.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from cronometer_api_mcp.client import CronometerClient
+
+
+class FakeResp:
+    def __init__(self, body, status: int = 200) -> None:
+        self._body = body
+        self.status_code = status
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def json(self):
+        return self._body
+
+
+def _client(tmp_path: Path, timezone: str) -> CronometerClient:
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "TOKEN"
+    client._timezone = timezone
+    return client
+
+
+def _capture_serving(client: CronometerClient) -> dict:
+    """Stub the POST so add_serving returns a success body and record the
+    serving payload the client sent."""
+    captured: dict = {}
+
+    def fake_post(endpoint, json=None):
+        captured["endpoint"] = endpoint
+        captured["payload"] = json
+        return FakeResp({"result": "SUCCESS", "id": 999})
+
+    client._http.post = fake_post  # type: ignore[method-assign]
+    return captured
+
+
+class FrozenDatetime(_dt.datetime):
+    """datetime whose now() ignores the host clock and returns a fixed UTC
+    instant, correctly converted into whatever tz is requested."""
+
+    _fixed_utc = _dt.datetime(2026, 7, 27, 18, 1, 30, tzinfo=_dt.timezone.utc)
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            # Naive now() in the *host* zone. Force UTC to simulate a UTC server.
+            return cls._fixed_utc.replace(tzinfo=None)
+        return cls._fixed_utc.astimezone(tz)
+
+
+@pytest.fixture
+def frozen_utc(monkeypatch):
+    """Freeze wall-clock time to 2026-07-27 18:01:30 UTC (== 11:01 PDT)."""
+    monkeypatch.setattr("cronometer_api_mcp.client.datetime", FrozenDatetime)
+
+
+def test_stamps_in_account_timezone_not_host(tmp_path, frozen_utc):
+    """Los Angeles account, UTC host: 18:01 UTC must record as 11:01 local,
+    land on today's LA date, and auto-group as Lunch (not Dinner)."""
+    client = _client(tmp_path, "America/Los_Angeles")
+    captured = _capture_serving(client)
+
+    client.add_serving(food_id=1, measure_id=0, grams=100.0)
+
+    serving = captured["payload"]["serving"]
+    assert serving["time"] == "11:1:30"
+    assert serving["day"] == "2026-7-27"
+    # 11:00 local -> Lunch (group 2); order == (2 << 16) | 1
+    assert serving["order"] == (2 << 16) | 1
+    # Matches the native app: no offset stored alongside the wall-clock time.
+    assert serving["offset"] is None
+
+
+def test_day_bucketing_respects_account_timezone(tmp_path, frozen_utc):
+    """18:01 UTC is already 'tomorrow' in the host-UTC sense for a late-evening
+    logger, but for LA it is still 2026-07-27 -- the entry must not slip a day."""
+    client = _client(tmp_path, "America/Los_Angeles")
+    captured = _capture_serving(client)
+
+    client.add_serving(food_id=1, measure_id=0, grams=100.0)
+
+    assert captured["payload"]["serving"]["day"] == "2026-7-27"
+    assert client.today() == _dt.date(2026, 7, 27)
+
+
+def test_explicit_day_is_unchanged(tmp_path, frozen_utc):
+    """An explicitly supplied day is passed through verbatim (LLM connectors
+    almost always supply it); timezone only affects the default path."""
+    client = _client(tmp_path, "America/Los_Angeles")
+    captured = _capture_serving(client)
+
+    client.add_serving(food_id=1, measure_id=0, grams=100.0, day=_dt.date(2026, 1, 5))
+
+    assert captured["payload"]["serving"]["day"] == "2026-1-5"
+
+
+def test_explicit_diary_group_skips_auto(tmp_path, frozen_utc):
+    """A caller-chosen meal group is never overridden by the hour heuristic."""
+    client = _client(tmp_path, "America/Los_Angeles")
+    captured = _capture_serving(client)
+
+    client.add_serving(food_id=1, measure_id=0, grams=100.0, diary_group=3)
+
+    assert captured["payload"]["serving"]["order"] == (3 << 16) | 1
+
+
+def test_login_captures_account_timezone(tmp_path, monkeypatch):
+    """login() stores the timezone from the response and persists it."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    client = CronometerClient(session_path=tmp_path / "session.json")
+
+    def fake_post(endpoint, json=None):
+        return FakeResp(
+            {
+                "result": "SUCCESS",
+                "id": 6407976,
+                "sessionKey": "SESSIONKEY123",
+                "timezone": "America/Los_Angeles",
+            }
+        )
+
+    client._http.post = fake_post  # type: ignore[method-assign]
+    client.login()
+
+    assert client._timezone == "America/Los_Angeles"
+    # Persisted to the session cache for warm starts.
+    import json
+
+    saved = json.loads((tmp_path / "session.json").read_text())
+    assert saved["timezone"] == "America/Los_Angeles"
+
+
+def test_warm_start_restores_timezone(tmp_path, monkeypatch):
+    """A cache file with a timezone is restored without re-login."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "")
+    import json
+
+    (tmp_path / "session.json").write_text(
+        json.dumps(
+            {
+                "username": "",
+                "user_id": 123,
+                "token": "TOKEN",
+                "timezone": "America/Chicago",
+            }
+        )
+    )
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    assert client._token == "TOKEN"
+    assert client._timezone == "America/Chicago"
+
+
+def test_pre_timezone_cache_is_rejected(tmp_path, monkeypatch):
+    """A legacy cache lacking a timezone is treated as invalid so the next
+    login refreshes the account zone."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "")
+    import json
+
+    (tmp_path / "session.json").write_text(
+        json.dumps({"username": "", "user_id": 123, "token": "TOKEN"})
+    )
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    assert client._token is None
+    assert client._timezone is None
+
+
+def test_unknown_timezone_falls_back(tmp_path):
+    """An unresolvable zone name falls back rather than raising."""
+    client = _client(tmp_path, "Not/AZone")
+    assert client._tzinfo() == ZoneInfo("America/New_York")

--- a/uv.lock
+++ b/uv.lock
@@ -103,6 +103,7 @@ dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "mcp" },
     { name = "python-dotenv" },
+    { name = "tzdata" },
 ]
 
 [package.dev-dependencies]
@@ -116,6 +117,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -588,6 +590,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
add_serving derived time, meal group, and "today" from naive datetime.now()/date.today(), which read the server process's zone. Containerized deploys run at UTC, so a remote server logged entries at the wrong time, mislabeled the meal group, and could file them to the wrong diary day.

Resolve the timezone from the account profile in the login response, cache it with the session, and compute all wall-clock time and default dates in that zone. offset stays null to match the native app. Bundle tzdata so ZoneInfo resolves zones on Alpine and Windows.

Closes #24