### PR TITLE
Cap mcp below 2.x so fresh installs don't crash on import

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Edit the declared ranges, not just the lock: pyproject.toml is what PyPI
+    # consumers resolve against, so a breaking release has to surface there.
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    groups:
+      dev-tooling:
+        dependency-type: "development"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    # <2 until the MCPServer migration: 2.x moved mcp.server.fastmcp
+    "mcp>=1.29.0,<2",
     "httpx[socks]>=0.27.0",
     "python-dotenv>=1.0.0",
     "tzdata>=2024.1",

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -1,0 +1,67 @@
+"""Import and tool-registration tests for the server module.
+
+server.py is imported by the console entry point, so an import-time failure
+takes the whole server down before it serves a request -- and nothing else in
+the suite imports it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+EXPECTED_TOOLS = {
+    "add_custom_food",
+    "add_food_entry",
+    "copy_day",
+    "get_biometrics",
+    "get_daily_nutrition",
+    "get_fasting_history",
+    "get_fasting_stats",
+    "get_food_details",
+    "get_food_log",
+    "get_macro_targets",
+    "get_nutrition_scores",
+    "list_biometrics",
+    "mark_day_complete",
+    "remove_food_entry",
+    "search_foods",
+}
+
+
+def test_server_module_imports():
+    """The entry point does `from cronometer_api_mcp.server import main`."""
+    from cronometer_api_mcp import server
+
+    assert callable(server.main)
+
+
+def test_server_identity():
+    from cronometer_api_mcp.server import mcp
+
+    assert mcp.name == "cronometer"
+
+
+def test_registered_tools():
+    """Tools register as an import side effect of the @mcp.tool() decorators.
+
+    Descriptions come from the docstrings and are what the model reads to pick
+    a tool, so an empty one is a silent regression.
+    """
+    from cronometer_api_mcp.server import mcp
+
+    tools = asyncio.run(mcp.list_tools())
+
+    assert {tool.name for tool in tools} == EXPECTED_TOOLS
+    for tool in tools:
+        assert tool.description, f"{tool.name} has no description"
+
+
+def test_no_client_constructed_at_import():
+    """Import must not need credentials or touch the network.
+
+    The server is spawned fresh for every stdio session; the client is built
+    lazily on the first tool call instead.
+    """
+    from cronometer_api_mcp import server
+
+    assert server._client is None

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.29.0,<2" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "tzdata", specifier = ">=2024.1" },
 ]
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -295,9 +295,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pyproject.toml declared `mcp>=1.0.0` with no upper bound, so a fresh `uvx cronometer-api-mcp` resolved mcp 2.0.0 - which renamed FastMCP to MCPServer and moved mcp.server.fastmcp to mcp.server.mcpserver - and server.py died at import before serving a request.

Closes #37