### PR TITLE
Added extra nutrients for custom foods

### DIFF
--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -69,6 +69,27 @@ NUTRIENT_IDS = {
     "omega_6": 10002,
 }
 
+# Nutrient IDs create_custom_food() already writes via its named macro args
+# (including the derived/negative-ID duplicates it sends alongside them).
+# extra_nutrients must not reuse one of these -- see create_custom_food().
+_RESERVED_CUSTOM_FOOD_NUTRIENT_IDS = frozenset(
+    {
+        NUTRIENT_IDS["energy"],
+        NUTRIENT_IDS["protein"],
+        NUTRIENT_IDS["fat"],
+        NUTRIENT_IDS["carbs"],
+        NUTRIENT_IDS["fiber"],
+        NUTRIENT_IDS["sugar"],
+        NUTRIENT_IDS["sodium"],
+        NUTRIENT_IDS["saturated_fat"],
+        NUTRIENT_IDS["net_carbs"],
+        -203,
+        -204,
+        -205,
+        -221,
+    }
+)
+
 # Macro fields surfaced as a flat convenience block in the daily summary,
 # mapped to their nutrient IDs. These are the values most relevant when
 # summarizing a day at a glance.
@@ -559,6 +580,7 @@ class CronometerClient:
         sugar_g: float = 0,
         sodium_mg: float = 0,
         saturated_fat_g: float = 0,
+        extra_nutrients: dict[int, float] | None = None,
         serving_name: str = "1 serving",
         serving_grams: float = 100.0,
     ) -> dict:
@@ -567,6 +589,17 @@ class CronometerClient:
         Nutrient amounts are per the full serving (serving_grams).
         They are normalized to per-100g internally, since Cronometer stores
         all nutrient data on a per-100g basis.
+
+        Args:
+            extra_nutrients: Additional nutrients beyond the core macros above
+                (vitamins, minerals, amino acids, individual fatty acids,
+                etc.), keyed by Cronometer nutrient ID and valued per the full
+                serving like the named macro args. Use get_nutrient_definitions()
+                to look up IDs -- the account's full nutrient catalog (~95
+                entries) rather than the small NUTRIENT_IDS convenience map.
+                Must not reuse an ID already written by the named macro args
+                above; doing so raises ValueError rather than silently
+                duplicating or shadowing an entry.
 
         Returns {"food_id": int, "measure_id": int | None}.
         """
@@ -594,6 +627,19 @@ class CronometerClient:
             {"id": -221, "amount": 0},  # alcohol
             {"id": NUTRIENT_IDS["net_carbs"], "amount": round(net_carbs * scale, 2)},
         ]
+
+        if extra_nutrients:
+            overlap = set(extra_nutrients) & _RESERVED_CUSTOM_FOOD_NUTRIENT_IDS
+            if overlap:
+                raise ValueError(
+                    f"extra_nutrients overlaps IDs already set by the named "
+                    f"macro args: {sorted(overlap)}. Use the named args for "
+                    f"those instead."
+                )
+            nutrients.extend(
+                {"id": nid, "amount": round(amount * scale, 2)}
+                for nid, amount in extra_nutrients.items()
+            )
 
         payload = {
             "data": {

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -569,10 +569,11 @@ def add_custom_food(
         sodium_mg: Sodium per serving (mg, default 0).
         saturated_fat_g: Saturated fat per serving (g, default 0).
         extra_nutrients: Additional nutrients beyond the core macros above
-            (vitamins, minerals, amino acids, individual fatty acids, etc.),
-            keyed by Cronometer nutrient ID and valued per the full serving
-            like the other args. Must not reuse an ID already covered by the
-            named macro args.
+            (vitamins, minerals, amino acids, etc.), keyed by Cronometer
+            nutrient ID (from get_daily_nutrition, which pairs each id with
+            its name) and valued per the full serving. IDs aren't validated,
+            so a wrong one writes the wrong nutrient; must not reuse an ID the
+            named macro args already cover.
         serving_name: Name for the serving size (default "1 serving").
         serving_grams: Weight of one serving in grams (default 100).
     """

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -549,6 +549,7 @@ def add_custom_food(
     sugar_g: float = 0,
     sodium_mg: float = 0,
     saturated_fat_g: float = 0,
+    extra_nutrients: dict[int, float] | None = None,
     serving_name: str = "1 serving",
     serving_grams: float = 100.0,
 ) -> str:
@@ -567,6 +568,11 @@ def add_custom_food(
         sugar_g: Sugar per serving (g, default 0).
         sodium_mg: Sodium per serving (mg, default 0).
         saturated_fat_g: Saturated fat per serving (g, default 0).
+        extra_nutrients: Additional nutrients beyond the core macros above
+            (vitamins, minerals, amino acids, individual fatty acids, etc.),
+            keyed by Cronometer nutrient ID and valued per the full serving
+            like the other args. Must not reuse an ID already covered by the
+            named macro args.
         serving_name: Name for the serving size (default "1 serving").
         serving_grams: Weight of one serving in grams (default 100).
     """
@@ -582,6 +588,7 @@ def add_custom_food(
             sugar_g=sugar_g,
             sodium_mg=sodium_mg,
             saturated_fat_g=saturated_fat_g,
+            extra_nutrients=extra_nutrients,
             serving_name=serving_name,
             serving_grams=serving_grams,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -321,6 +321,47 @@ def test_enrich_diary_is_best_effort_when_get_foods_fails(tmp_path):
     assert out["diary"] == original["diary"]
 
 
+# ---------------------------------------------------------------------------
+# create_custom_food: extra_nutrients
+# ---------------------------------------------------------------------------
+
+
+def test_create_custom_food_extra_nutrients_payload(tmp_path):
+    """extra_nutrients are appended, normalized to per-100g like the macros."""
+    client, state = make_cold_client(tmp_path, [{"result": "SUCCESS", "id": 555}])
+
+    client.create_custom_food(
+        "Test Food",
+        calories=200,
+        protein_g=10,
+        fat_g=5,
+        carbs_g=20,
+        serving_grams=200.0,  # scale = 0.5
+        extra_nutrients={601: 30.0, 430: 10.0},  # cholesterol, vitamin K
+    )
+
+    nutrients = state["payloads"][0]["data"]["nutrients"]
+    by_id = {n["id"]: n["amount"] for n in nutrients}
+    assert by_id[601] == 15.0  # 30 * 0.5
+    assert by_id[430] == 5.0  # 10 * 0.5
+
+
+def test_create_custom_food_extra_nutrients_overlap_raises(tmp_path):
+    """Reusing an ID the named macro args already write is rejected, not
+    silently duplicated or shadowed."""
+    client, _ = make_client(tmp_path, [{"result": "SUCCESS", "id": 555}])
+
+    with pytest.raises(ValueError):
+        client.create_custom_food(
+            "Test Food",
+            calories=200,
+            protein_g=10,
+            fat_g=5,
+            carbs_g=20,
+            extra_nutrients={204: 5.0},  # fat -- already set by fat_g
+        )
+
+
 def test_enrich_diary_no_servings_skips_lookup(tmp_path):
     client = _enrich_client(tmp_path)
     calls = {"n": 0}


### PR DESCRIPTION
## What

`create_custom_food` gains an optional `extra_nutrients: dict[int, float]`,
keyed by Cronometer nutrient ID and valued per serving like the existing
named arguments. `add_custom_food` passes it through.

## Why

The named arguments cover eight nutrients. `get_nutrient_definitions()`
returns ninety-five for my account, including everything from individual
tocopherols and carotenoids to all twenty amino acids and EPA/DHA/ALA
separately. None of those could be written.

I'm generating full nutrient profiles offline and pushing them in, so the
gap was the whole blocker.

## Design notes

The signature is already keyword-only after `name`, so adding a defaulted
parameter is strictly additive — no existing call site changes.

Passing an ID that a named argument already writes raises `ValueError`
rather than silently duplicating or shadowing the entry. The reserved set
includes the derived negative IDs (-203/-204/-205/-221) the method sends
alongside the real ones, since those aren't obvious to a caller.

Amounts are normalized to per-100g on the same `scale` as the named
arguments, so the two paths can't drift.

No static nutrient table is added. IDs are the caller's to supply, resolved
from `get_nutrient_definitions()` at runtime, so nutrients Cronometer adds
later work with no code change.

## Tests

Two: that extras land in the payload correctly scaled, and that an
overlapping ID raises.