### PR TITLE
Add recipe creation functions

### DIFF
--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -68,6 +68,10 @@ NUTRIENT_IDS = {
     "omega_6": 10002,
 }
 
+# Grams per ounce, matching the value Cronometer's own web client sends for the
+# "oz" measure it attaches to every recipe.
+_OZ_GRAMS = 28.3495231
+
 # Macro fields surfaced as a flat convenience block in the daily summary,
 # mapped to their nutrient IDs. These are the values most relevant when
 # summarizing a day at a glance.
@@ -598,6 +602,180 @@ class CronometerClient:
 
         logger.info("Created custom food %r (id=%d)", name, food_id)
         return {"food_id": food_id, "measure_id": None}
+
+    # ------------------------------------------------------------------
+    # Recipe creation
+    # ------------------------------------------------------------------
+
+    def create_recipe(
+        self,
+        name: str,
+        *,
+        ingredients: list[tuple],
+        serving_name: str = "Serving",
+        serving_grams: float | None = None,
+        comments: str | None = None,
+    ) -> dict:
+        """Create a recipe -- a food composed of other foods -- in Cronometer.
+
+        Recipes go through the same /api/v2/add_food endpoint as custom foods;
+        what makes a food a recipe is the presence of an `ingredients` array.
+        Each ingredient references another food by ID plus a gram weight, and
+        the recipe stores a nutrient profile aggregated from those ingredients.
+
+        This creates a *weight-based* recipe: measures are type "Weight" and
+        nutrients are stored per-100g, matching create_custom_food's convention.
+        (Cronometer's other mode, "serving-based", uses type "Recipe" measures
+        and stores nutrients per full batch, which makes the diary's `grams`
+        field a serving count instead of real grams -- see
+        enrich_diary_servings. Weight-based avoids that quirk entirely.)
+
+        Args:
+            name: Recipe name.
+            ingredients: List of (food_id, grams) tuples, or
+                (food_id, grams, measure_id) to override the ingredient's
+                display measure. The measure only affects how the amount is
+                rendered in Cronometer's UI (amount = grams / measure value);
+                `grams` is always what the nutrient math uses. When omitted,
+                the ingredient's own gram measure is resolved automatically.
+            serving_name: Name of the default serving measure.
+            serving_grams: Grams in one serving. Defaults to the full batch
+                weight (i.e. one serving = the whole recipe).
+            comments: Free-text recipe notes.
+
+        Returns {"food_id": int, "total_grams": float, "ingredient_count": int}.
+        """
+        if not ingredients:
+            raise ValueError("create_recipe requires at least one ingredient")
+
+        # Normalize to (food_id, grams, measure_id|None) and validate up front so
+        # a malformed entry fails before any network call.
+        parsed: list[tuple[int, float, int | None]] = []
+        for item in ingredients:
+            if len(item) == 2:
+                food_id, grams = item
+                measure_id = None
+            elif len(item) == 3:
+                food_id, grams, measure_id = item
+            else:
+                raise ValueError(
+                    f"Each ingredient must be (food_id, grams) or "
+                    f"(food_id, grams, measure_id); got {item!r}"
+                )
+            if grams <= 0:
+                raise ValueError(
+                    f"Ingredient grams must be positive; food {food_id} got {grams!r}"
+                )
+            parsed.append((int(food_id), float(grams), measure_id))
+
+        total_grams = sum(g for _, g, _ in parsed)
+
+        # One batch call resolves every ingredient's measures, translation, and
+        # per-100g nutrient profile.
+        foods = self.get_foods([fid for fid, _, _ in parsed])
+        food_by_id = {f.get("id"): f for f in foods if isinstance(f, dict)}
+        missing = [fid for fid, _, _ in parsed if fid not in food_by_id]
+        if missing:
+            raise CronometerError(f"Ingredient food IDs not found: {missing}")
+
+        ingredient_rows: list[dict] = []
+        batch_totals: dict[int, float] = {}
+        for food_id, grams, measure_id in parsed:
+            food = food_by_id[food_id]
+            if measure_id is None:
+                measure_id = _gram_measure_id(food)
+            ingredient_rows.append(
+                {
+                    "id": 0,
+                    "foodId": food_id,
+                    "measureId": measure_id,
+                    "translationId": _translation_id(food),
+                    "grams": grams,
+                    "value": grams,
+                }
+            )
+            # Ingredient nutrients are per-100g; accumulate the batch total.
+            for n in food.get("nutrients", []):
+                if not isinstance(n, dict):
+                    continue
+                nid = n.get("id")
+                amount = n.get("amount")
+                if nid is None or not isinstance(amount, (int, float)):
+                    continue
+                batch_totals[nid] = batch_totals.get(nid, 0.0) + amount * grams / 100.0
+
+        # Cronometer stores recipe nutrients per-100g of the finished batch.
+        scale = 100.0 / total_grams
+        nutrients = [
+            {"id": nid, "amount": round(amount * scale, 6)}
+            for nid, amount in sorted(batch_totals.items())
+        ]
+
+        # The first measure in the array becomes the server-assigned
+        # defaultMeasureId, so the serving measure leads.
+        measures = [
+            {
+                "id": 0,
+                "name": serving_name,
+                "value": total_grams if serving_grams is None else serving_grams,
+                "amount": 1.0,
+                "type": "Weight",
+            },
+            {"id": 0, "name": "g", "value": 1.0, "amount": 1.0, "type": "Weight"},
+            {
+                "id": 0,
+                "name": "oz",
+                "value": _OZ_GRAMS,
+                "amount": 1.0,
+                "type": "Weight",
+            },
+            {
+                "id": 0,
+                "name": "full recipe",
+                "value": total_grams,
+                "amount": 1.0,
+                "type": "Weight",
+            },
+        ]
+
+        payload = {
+            "data": {
+                "id": 0,
+                "name": name,
+                "category": 0,
+                "owner": None,
+                "retired": None,
+                "source": None,
+                "defaultMeasureId": 0,
+                "comments": comments,
+                "alternateId": None,
+                "ingredients": ingredient_rows,
+                "measures": measures,
+                "labelType": "AMERICAN_2016",
+                "nutrients": nutrients,
+                "properties": {"advancedServingSize": "false"},
+                "foodTags": [],
+            },
+            "config": {"call_version": 1},
+        }
+
+        data = self._request("/api/v2/add_food", payload)
+        food_id = data.get("id")
+        if not food_id:
+            raise CronometerError(f"Failed to create recipe: {data}")
+
+        logger.info(
+            "Created recipe %r (id=%d, %d ingredients, %.1fg batch)",
+            name,
+            food_id,
+            len(ingredient_rows),
+            total_grams,
+        )
+        return {
+            "food_id": food_id,
+            "total_grams": total_grams,
+            "ingredient_count": len(ingredient_rows),
+        }
 
     # ------------------------------------------------------------------
     # Diary: add serving
@@ -1192,6 +1370,31 @@ class CronometerClient:
 # ======================================================================
 # Helpers
 # ======================================================================
+
+
+def _gram_measure_id(food: dict) -> int:
+    """Return the food's gram measure ID, for use as a recipe ingredient.
+
+    Ingredient measures are display metadata -- Cronometer renders the amount
+    as grams / measure value -- so the 1-gram measure makes the UI show the
+    gram weight directly. Falls back to the food's default measure when no
+    gram measure exists, since `grams` is what the nutrient math uses either
+    way.
+    """
+    for m in food.get("measures", []):
+        if isinstance(m, dict) and m.get("name") == "g" and m.get("value") == 1:
+            return m["id"]
+    return food.get("defaultMeasureId") or 0
+
+
+def _translation_id(food: dict) -> int:
+    """Return the food's primary translation ID, or 0 if it has none."""
+    translations = food.get("translations")
+    if isinstance(translations, list) and translations:
+        first = translations[0]
+        if isinstance(first, dict):
+            return first.get("translationId") or 0
+    return 0
 
 
 def _meal_group_for_hour(hour: int) -> int:

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -578,6 +578,84 @@ def add_custom_food(
 
 
 # ------------------------------------------------------------------
+# Recipe creation
+# ------------------------------------------------------------------
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    }
+)
+def add_recipe(
+    name: str,
+    ingredients: list[dict],
+    serving_name: str = "Serving",
+    serving_grams: float | None = None,
+    comments: str | None = None,
+) -> str:
+    """Create a recipe in Cronometer from other foods in the database.
+
+    Unlike add_custom_food, which takes hand-entered nutrition, a recipe
+    references existing foods by ID and Cronometer derives the full nutrient
+    profile (including micronutrients) from those ingredients.
+
+    Use search_foods to find each ingredient's food_id. After creation, use
+    the returned food_id with add_food_entry to log it.
+
+    Args:
+        name: Recipe name.
+        ingredients: List of {"food_id": int, "grams": float} objects, one per
+            ingredient. An optional "measure_id" overrides the unit shown in
+            Cronometer's UI; "grams" always drives the nutrition math.
+        serving_name: Name of the default serving measure (default "Serving").
+        serving_grams: Grams in one serving. Defaults to the full batch weight
+            (one serving = the whole recipe).
+        comments: Free-text recipe notes.
+    """
+    try:
+        parsed = []
+        for item in ingredients:
+            if "food_id" not in item or "grams" not in item:
+                return _err(
+                    ValueError(
+                        f"Each ingredient needs 'food_id' and 'grams'; got {item!r}"
+                    )
+                )
+            if item.get("measure_id") is not None:
+                parsed.append((item["food_id"], item["grams"], item["measure_id"]))
+            else:
+                parsed.append((item["food_id"], item["grams"]))
+
+        client = _get_client()
+        result = client.create_recipe(
+            name,
+            ingredients=parsed,
+            serving_name=serving_name,
+            serving_grams=serving_grams,
+            comments=comments,
+        )
+
+        # Fetch back to get the server-assigned measure_id
+        food_data = client.get_food(result["food_id"])
+        return _ok(
+            {
+                "food_id": result["food_id"],
+                "measure_id": food_data.get("defaultMeasureId"),
+                "name": name,
+                "total_grams": result["total_grams"],
+                "ingredient_count": result["ingredient_count"],
+                "note": "Use food_id and measure_id with add_food_entry to log this recipe.",
+            }
+        )
+    except Exception as e:
+        return _err(e)
+
+
+# ------------------------------------------------------------------
 # Macro targets
 # ------------------------------------------------------------------
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -319,6 +319,160 @@ def test_enrich_diary_is_best_effort_when_get_foods_fails(tmp_path):
     assert out["diary"] == original["diary"]
 
 
+# ---------------------------------------------------------------------------
+# create_recipe
+#
+# Recipes post to the same /api/v2/add_food endpoint as custom foods; the
+# `ingredients` array is what makes a food a recipe. Nutrients are aggregated
+# from the ingredients' per-100g profiles and re-normalized to per-100g of the
+# finished batch. Verified against the live API (food 79474948).
+# ---------------------------------------------------------------------------
+
+RECIPE_INGREDIENT_FOODS = [
+    {
+        "id": 1000,
+        "name": "Sardines",
+        "defaultMeasureId": 11,
+        "measures": [
+            {"id": 10, "name": "oz", "value": 28.3495231, "type": "Weight"},
+            {"id": 11, "name": "g", "value": 1, "type": "Weight"},
+        ],
+        "translations": [{"translationId": 555, "name": "Sardines"}],
+        # per-100g
+        "nutrients": [{"id": 208, "amount": 200.0}, {"id": 203, "amount": 25.0}],
+    },
+    {
+        "id": 2000,
+        "name": "Marshmallow Creme",
+        "defaultMeasureId": 21,
+        "measures": [{"id": 21, "name": "g", "value": 1, "type": "Weight"}],
+        # no translations -> translationId falls back to 0
+        "nutrients": [{"id": 208, "amount": 300.0}, {"id": 205, "amount": 60.0}],
+    },
+]
+
+
+def _recipe_client(tmp_path: Path, responses=None):
+    client, state = make_cold_client(
+        tmp_path, responses or [{"result": "SUCCESS", "id": 4242}]
+    )
+    client.get_foods = lambda ids: RECIPE_INGREDIENT_FOODS  # type: ignore[method-assign]
+    return client, state
+
+
+def test_create_recipe_payload_shape(tmp_path):
+    """Ingredients, weight-based measures, and per-100g aggregate nutrients."""
+    client, state = _recipe_client(tmp_path)
+
+    result = client.create_recipe(
+        "Test Recipe", ingredients=[(1000, 100.0), (2000, 50.0)]
+    )
+
+    assert result == {"food_id": 4242, "total_grams": 150.0, "ingredient_count": 2}
+    data = state["payloads"][0]["data"]
+
+    # A new food, with ingredients -- the marker that makes it a recipe.
+    assert data["id"] == 0
+    assert data["defaultMeasureId"] == 0
+    assert data["properties"] == {"advancedServingSize": "false"}
+    assert data["ingredients"] == [
+        {
+            "id": 0,
+            "foodId": 1000,
+            "measureId": 11,  # resolved to the 1-gram measure, not defaultMeasureId
+            "translationId": 555,
+            "grams": 100.0,
+            "value": 100.0,
+        },
+        {
+            "id": 0,
+            "foodId": 2000,
+            "measureId": 21,
+            "translationId": 0,  # no translations on this food
+            "grams": 50.0,
+            "value": 50.0,
+        },
+    ]
+
+    # Weight-based: every measure is type "Weight" (not "Recipe"), so the diary
+    # treats logged amounts as real grams rather than a serving count.
+    assert [m["type"] for m in data["measures"]] == ["Weight"] * 4
+    by_name = {m["name"]: m["value"] for m in data["measures"]}
+    assert by_name == {
+        "Serving": 150.0,  # defaults to the full batch
+        "g": 1.0,
+        "oz": 28.3495231,
+        "full recipe": 150.0,
+    }
+    # The serving measure leads, since the server makes the first one default.
+    assert data["measures"][0]["name"] == "Serving"
+
+    # Batch: 200*1.0 + 300*0.5 = 350 kcal over 150g -> 233.333333 per 100g.
+    amounts = {n["id"]: n["amount"] for n in data["nutrients"]}
+    assert amounts[208] == 233.333333
+    assert amounts[203] == round(25.0 * 100 / 150, 6)  # only in the sardines
+    assert amounts[205] == round(60.0 * 50 / 150, 6)  # only in the creme
+
+
+def test_create_recipe_explicit_serving_and_comments(tmp_path):
+    client, state = _recipe_client(tmp_path)
+
+    client.create_recipe(
+        "Test Recipe",
+        ingredients=[(1000, 100.0), (2000, 50.0)],
+        serving_name="bowl",
+        serving_grams=75.0,
+        comments="wildly inadvisable",
+    )
+
+    data = state["payloads"][0]["data"]
+    assert data["measures"][0] == {
+        "id": 0,
+        "name": "bowl",
+        "value": 75.0,
+        "amount": 1.0,
+        "type": "Weight",
+    }
+    # An explicit serving size must not change the batch weight.
+    assert {m["name"]: m["value"] for m in data["measures"]}["full recipe"] == 150.0
+    assert data["comments"] == "wildly inadvisable"
+
+
+def test_create_recipe_measure_id_override(tmp_path):
+    """A 3-tuple overrides the auto-resolved display measure."""
+    client, state = _recipe_client(tmp_path)
+
+    client.create_recipe("Test Recipe", ingredients=[(1000, 100.0, 10)])
+
+    assert state["payloads"][0]["data"]["ingredients"][0]["measureId"] == 10
+
+
+def test_create_recipe_rejects_empty_and_malformed(tmp_path):
+    client, state = _recipe_client(tmp_path)
+
+    with pytest.raises(ValueError):
+        client.create_recipe("Test Recipe", ingredients=[])
+
+    with pytest.raises(ValueError):
+        client.create_recipe("Test Recipe", ingredients=[(1000,)])
+
+    with pytest.raises(ValueError):
+        client.create_recipe("Test Recipe", ingredients=[(1000, 0)])
+
+    # Validation happens before any network call.
+    assert state["post"] == 0
+
+
+def test_create_recipe_missing_ingredient_food_raises(tmp_path):
+    """An unresolvable food ID fails loudly rather than silently dropping it."""
+    client, state = _recipe_client(tmp_path)
+
+    with pytest.raises(CronometerError):
+        client.create_recipe("Test Recipe", ingredients=[(1000, 100.0), (9999, 10.0)])
+
+    assert state["post"] == 0
+
+
 def test_enrich_diary_no_servings_skips_lookup(tmp_path):
     client = _enrich_client(tmp_path)
     calls = {"n": 0}

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -12,6 +12,7 @@ import asyncio
 EXPECTED_TOOLS = {
     "add_custom_food",
     "add_food_entry",
+    "add_recipe",
     "copy_day",
     "get_biometrics",
     "get_daily_nutrition",


### PR DESCRIPTION
## What

`create_recipe(name, ingredients=[(food_id, grams), ...])` on the client,
plus an `add_recipe` MCP tool.

## How the payload shape was established

Recipes go through the existing `/api/v2/add_food` endpoint — what makes a
food a recipe is the presence of an `ingredients` array. I confirmed that
rather than assuming it.

Shape came from decoding the web app's GWT-RPC `addFood`/`editFood` calls
across five captures (serving-based and weight-based, simple and advanced
serving sizes), then reading the results back through this client to see
how the mobile API represents the same food. I did not attempt to intercept
the mobile app.

Verified with one POST and a read-back diff (food 79474948):

- ingredients round-trip exactly — foodId, measureId, translationId and
  grams all preserved, with server-assigned row IDs
- all four measures preserved with their exact values
- `defaultMeasureId` sent as 0 comes back assigned from the *first* measure
  in the array
- 93 nutrients sent, 90 stored: 318, 325 and 326 were dropped as outside
  the account's catalog
- net carbs is recomputed server-side as carbs − fibre − sugar alcohol, so
  sending it is advisory
- `source` and `owner` sent as null come back set correctly

## Design notes

Weight-based rather than serving-based. Cronometer supports both: serving-
based recipes use `type: "Recipe"` measures and store nutrients per batch,
which is what makes the diary's `grams` field a serving count — the quirk
`enrich_diary_servings` already handles. Weight-based uses `type: "Weight"`
measures with nutrients per-100g, matching `create_custom_food`'s existing
convention and avoiding that quirk entirely.

Ingredients are `(food_id, grams)`. The measure ID is display metadata —
Cronometer renders the amount as grams / measure value — so it's resolved
automatically to the food's gram measure. A three-tuple overrides it where
that matters.

One batched `get_foods` resolves every ingredient. Unresolvable IDs raise
rather than being silently dropped. Input is validated before any network
call, so a malformed tuple fails fast.

## Tests

Five: payload shape (ingredients, weight-based measures, per-100g
aggregation), explicit serving size and comments, measure-ID override,
input validation, and missing-food handling. Plus `add_recipe` added to the
tool-registry set — which caught the omission on its first run.