### PR TITLE
Migrate to MCP SDK 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN uv python install 3.14 \
 # in supergateway's own node_modules to a release that covers the versions the
 # Python `mcp` package negotiates.
 #
+# Python mcp 2.x still handshakes at 2025-11-25, which this Node SDK range
+# covers; its 2026-07-28 revision is reachable only via `server/discover`.
+# Re-check this pin only if a release adds a *handshake* version.
+#
 # NOTE: this is a per-image mitigation, not the durable fix. supergateway
 # proxies `initialize` verbatim but then validates the negotiated version
 # against its own (possibly older) SDK, so the skew recurs whenever the wrapped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.14",
-    "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 dependencies = [
-    # <2 until the MCPServer migration: 2.x moved mcp.server.fastmcp
-    "mcp>=1.29.0,<2",
+    "mcp>=2.0.0,<3",
     "httpx[socks]>=0.27.0",
     "python-dotenv>=1.0.0",
     "tzdata>=2024.1",

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -12,6 +12,7 @@ endpoints.
 import json
 import logging
 import os
+import threading
 from datetime import date, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -91,6 +92,10 @@ class CronometerClient:
 
     Caches the auth token in memory and reuses it across requests.
     Re-authenticates automatically when the session expires.
+
+    Thread safety: one instance is shared across MCP tool calls, which the SDK
+    dispatches on worker threads. Only auth state transitions are serialized;
+    requests still run concurrently. See `_auth_lock`.
     """
 
     def __init__(self, *, session_path: Path | None = None) -> None:
@@ -101,6 +106,9 @@ class CronometerClient:
         # are computed in this zone so behavior is independent of the host clock.
         self._timezone: str | None = None
         self._session_path: Path = session_path or _DEFAULT_SESSION_PATH
+        # Guards (_user_id, _token, _timezone) and the session file mirroring
+        # them. Reentrant because the auth paths nest: login -> _save_cached_session.
+        self._auth_lock = threading.RLock()
         # Cache of nutrient definitions (id -> {name, unit, category}).
         # Definitions are stable for an account, so fetch them once.
         self._nutrient_defs: dict[int, dict] | None = None
@@ -165,39 +173,41 @@ class CronometerClient:
 
     def _save_cached_session(self) -> None:
         """Persist (user_id, token, timezone) so future processes can reuse it."""
-        if self._user_id is None or self._token is None:
-            return
-        try:
-            self._session_path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = self._session_path.with_suffix(".json.tmp")
-            tmp.write_text(
-                json.dumps(
-                    {
-                        "username": self._cache_key(),
-                        "user_id": self._user_id,
-                        "token": self._token,
-                        "timezone": self._timezone,
-                    }
-                )
-            )
-            os.replace(tmp, self._session_path)
+        with self._auth_lock:
+            if self._user_id is None or self._token is None:
+                return
             try:
-                os.chmod(self._session_path, 0o600)
-            except OSError:
-                pass
-        except OSError as exc:
-            logger.warning("Failed to persist Cronometer session: %s", exc)
+                self._session_path.parent.mkdir(parents=True, exist_ok=True)
+                tmp = self._session_path.with_suffix(".json.tmp")
+                tmp.write_text(
+                    json.dumps(
+                        {
+                            "username": self._cache_key(),
+                            "user_id": self._user_id,
+                            "token": self._token,
+                            "timezone": self._timezone,
+                        }
+                    )
+                )
+                os.replace(tmp, self._session_path)
+                try:
+                    os.chmod(self._session_path, 0o600)
+                except OSError:
+                    pass
+            except OSError as exc:
+                logger.warning("Failed to persist Cronometer session: %s", exc)
 
     def _invalidate_session(self) -> None:
         """Drop the in-memory token and remove the cache file."""
-        self._token = None
-        self._timezone = None
-        try:
-            self._session_path.unlink()
-        except FileNotFoundError:
-            pass
-        except OSError as exc:
-            logger.debug("Could not remove cached session: %s", exc)
+        with self._auth_lock:
+            self._token = None
+            self._timezone = None
+            try:
+                self._session_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.debug("Could not remove cached session: %s", exc)
 
     def _get_credentials(self) -> tuple[str, str]:
         username = os.getenv("CRONOMETER_USERNAME")
@@ -209,7 +219,11 @@ class CronometerClient:
         return username, password
 
     def login(self) -> None:
-        """Authenticate with Cronometer and cache the session token."""
+        """Authenticate with Cronometer and cache the session token.
+
+        Holds the auth lock throughout, so concurrent callers queue instead of
+        each hitting the rate-limited login endpoint (#3).
+        """
         username, password = self._get_credentials()
 
         payload = {
@@ -242,32 +256,35 @@ class CronometerClient:
         }
 
         logger.info("Logging in to Cronometer as %s", username)
-        resp = self._http.post("/api/v2/login", json=payload)
-        resp.raise_for_status()
-        data = resp.json()
+        with self._auth_lock:
+            resp = self._http.post("/api/v2/login", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
 
-        if data.get("result") != "SUCCESS" and "sessionKey" not in data:
-            raise CronometerError(f"Login failed: {data}")
+            if data.get("result") != "SUCCESS" and "sessionKey" not in data:
+                raise CronometerError(f"Login failed: {data}")
 
-        self._user_id = data["id"]
-        self._token = data["sessionKey"]
-        # The login response embeds the account profile, including the user's
-        # configured IANA timezone. Prefer it over the host clock so diary
-        # timestamps are correct regardless of where the server runs. A
-        # CRONOMETER_ACCOUNT_TZ override, if set, wins over the response.
-        self._timezone = self._resolve_timezone(data.get("timezone"))
-        self._save_cached_session()
-        logger.info(
-            "Cronometer login successful (userId=%d, tz=%s, token=%s...)",
-            self._user_id,
-            self._timezone,
-            self._token[:8] if self._token else "???",
-        )
+            self._user_id = data["id"]
+            self._token = data["sessionKey"]
+            # The login response embeds the account profile, including the user's
+            # configured IANA timezone. Prefer it over the host clock so diary
+            # timestamps are correct regardless of where the server runs. A
+            # CRONOMETER_ACCOUNT_TZ override, if set, wins over the response.
+            self._timezone = self._resolve_timezone(data.get("timezone"))
+            self._save_cached_session()
+            logger.info(
+                "Cronometer login successful (userId=%d, tz=%s, token=%s...)",
+                self._user_id,
+                self._timezone,
+                self._token[:8] if self._token else "???",
+            )
 
     def _ensure_auth(self) -> None:
         """Login lazily on first use."""
         if self._token is None:
-            self.login()
+            with self._auth_lock:
+                if self._token is None:
+                    self.login()
 
     @property
     def user_id(self) -> int:
@@ -287,6 +304,22 @@ class CronometerClient:
     # Request helpers
     # ------------------------------------------------------------------
 
+    def _reauthenticate(self, stale_token: str | None) -> None:
+        """Re-login, unless another thread already replaced `stale_token`.
+
+        Comparing against the token the caller actually sent collapses a burst
+        of concurrent 401s into one login, so no thread discards a fresh token
+        a peer just won.
+        """
+        with self._auth_lock:
+            if self._token is not None and self._token != stale_token:
+                logger.debug(
+                    "Token already refreshed by another thread; skipping login"
+                )
+                return
+            self._invalidate_session()
+            self.login()
+
     def _request(self, endpoint: str, payload: dict, *, _retried: bool = False) -> dict:
         """Send a v2 POST request with JSON auth block. Re-authenticates once on failure.
 
@@ -297,6 +330,8 @@ class CronometerClient:
 
         payload["auth"] = self._auth_block()
         payload.setdefault("lastSeen", 0)
+        # A 401 is only our stale token's fault if this is still the live one.
+        sent_token = payload["auth"]["token"]
 
         logger.debug("Cronometer v2 request: POST %s", endpoint)
         resp = self._http.post(endpoint, json=payload)
@@ -307,8 +342,7 @@ class CronometerClient:
                 "Cronometer auth rejected (%d), re-authenticating",
                 resp.status_code,
             )
-            self._invalidate_session()
-            self.login()
+            self._reauthenticate(sent_token)
             return self._request(endpoint, payload, _retried=True)
 
         resp.raise_for_status()
@@ -320,8 +354,7 @@ class CronometerClient:
         if isinstance(data, dict) and data.get("result") in ("FAIL", "FAILURE"):
             if not _retried:
                 logger.warning("Cronometer request failed, re-authenticating: %s", data)
-                self._invalidate_session()
-                self.login()
+                self._reauthenticate(sent_token)
                 return self._request(endpoint, payload, _retried=True)
             raise CronometerError(f"Cronometer API error: {data}")
 
@@ -357,9 +390,9 @@ class CronometerClient:
         url = f"/api/v3/user/{self.user_id}{path}"
         logger.debug("Cronometer v3 request: %s %s", method, url)
 
-        resp = self._http.request(
-            method, url, json=json_body, headers=self._v3_headers()
-        )
+        headers = self._v3_headers()
+        sent_token = headers["x-crono-session"]
+        resp = self._http.request(method, url, json=json_body, headers=headers)
 
         # Re-authenticate once on auth failures
         if resp.status_code in (401, 403) and not _retried:
@@ -367,8 +400,7 @@ class CronometerClient:
                 "Cronometer v3 auth rejected (%d), re-authenticating",
                 resp.status_code,
             )
-            self._invalidate_session()
-            self.login()
+            self._reauthenticate(sent_token)
             return self._request_v3(method, path, json_body=json_body, _retried=True)
 
         return resp

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -2,16 +2,33 @@
 
 import json
 import logging
+import threading
 from datetime import date, timedelta
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from .client import CronometerClient
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP(
+
+def _server_version() -> str:
+    """Version reported in serverInfo.
+
+    Read from installed package metadata so the release tag (which publish.yml
+    stamps into pyproject.toml) is the single source of truth. The field is
+    display-only, so a missing distribution degrades to "" rather than failing.
+    """
+    try:
+        return _pkg_version("cronometer-api-mcp")
+    except PackageNotFoundError:
+        return ""
+
+
+mcp = MCPServer(
     "cronometer",
     instructions=(
         "Cronometer MCP server for nutrition tracking via the mobile REST API. "
@@ -21,15 +38,23 @@ mcp = FastMCP(
         "and serving sizes, add_food_entry to log meals, and get_food_log to "
         "review what was eaten."
     ),
+    version=_server_version(),
 )
 
 _client: CronometerClient | None = None
+# Guards the lazy construction below. SDK 2.x dispatches sync tool handlers on
+# worker threads, so concurrent first-calls would otherwise build a client each,
+# meaning two logins against a rate-limited endpoint (#3).
+_client_lock = threading.Lock()
 
 
 def _get_client() -> CronometerClient:
     global _client
     if _client is None:
-        _client = CronometerClient()
+        with _client_lock:
+            # Re-check: another thread may have won the race to the lock.
+            if _client is None:
+                _client = CronometerClient()
     return _client
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,8 @@ the failure was surfaced to callers as a success.
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -334,3 +336,130 @@ def test_enrich_diary_no_servings_skips_lookup(tmp_path):
     )
     assert calls["n"] == 0
     assert out["diary"] == [{"type": "Exercise", "name": "Running"}]
+
+
+# ---------------------------------------------------------------------------
+# Concurrent auth (MCP SDK 2.x)
+#
+# The SDK runs sync tool handlers on worker threads, so tool calls share one
+# client concurrently where 1.x serialized them. Auth is a read-modify-write
+# over (_user_id, _token, _timezone) plus a session-file write, so an unguarded
+# burst logs in once per thread against a rate-limited endpoint (#3).
+# ---------------------------------------------------------------------------
+
+THREADS = 8
+
+
+def test_concurrent_cold_start_logs_in_once(tmp_path):
+    """A burst of first-calls on a cold client triggers exactly one login."""
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = None
+    client._token = None
+
+    state = {"login": 0}
+    start = threading.Barrier(THREADS)
+
+    def fake_login() -> None:
+        # Widen the race window: without the lock every thread has already
+        # passed the `_token is None` check by the time the first one stores.
+        state["login"] += 1
+        time.sleep(0.05)
+        client._user_id = 42
+        client._token = "FRESH_TOKEN"
+
+    client.login = fake_login  # type: ignore[method-assign]
+
+    def worker() -> None:
+        start.wait()
+        client._ensure_auth()
+
+    threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert state["login"] == 1
+    assert client._token == "FRESH_TOKEN"
+
+
+def test_concurrent_expired_token_logs_in_once(tmp_path):
+    """Concurrent 401s on one stale token collapse into a single re-login."""
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "STALE_TOKEN"
+
+    state = {"login": 0}
+    lock = threading.Lock()
+    start = threading.Barrier(THREADS)
+
+    def fake_login() -> None:
+        with lock:
+            state["login"] += 1
+            n = state["login"]
+        time.sleep(0.05)
+        client._user_id = 123
+        client._token = f"FRESH_TOKEN_{n}"
+
+    def fake_post(endpoint, json=None):
+        # Reject the stale token, accept anything issued by a login.
+        if json["auth"]["token"] == "STALE_TOKEN":
+            return FakeResp(REAL_FAIL_BODY)
+        return FakeResp({"result": "SUCCESS"})
+
+    client.login = fake_login  # type: ignore[method-assign]
+    client._http.post = fake_post  # type: ignore[method-assign]
+
+    results = []
+
+    def worker() -> None:
+        start.wait()
+        results.append(client._request("/api/v2/get_diary", {}))
+
+    threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert state["login"] == 1
+    assert results == [{"result": "SUCCESS"}] * THREADS
+
+
+def test_reauthenticate_skips_login_when_token_already_refreshed(tmp_path):
+    """A caller holding an already-replaced token must not force a new login."""
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "FRESH_TOKEN"
+
+    state = {"login": 0}
+
+    def fake_login() -> None:
+        state["login"] += 1
+
+    client.login = fake_login  # type: ignore[method-assign]
+
+    client._reauthenticate("STALE_TOKEN")
+
+    assert state["login"] == 0
+    assert client._token == "FRESH_TOKEN"
+
+
+def test_reauthenticate_logs_in_when_token_is_still_stale(tmp_path):
+    """The thread that actually holds the current (stale) token does re-login."""
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 123
+    client._token = "STALE_TOKEN"
+
+    state = {"login": 0}
+
+    def fake_login() -> None:
+        state["login"] += 1
+        client._token = "FRESH_TOKEN"
+
+    client.login = fake_login  # type: ignore[method-assign]
+
+    client._reauthenticate("STALE_TOKEN")
+
+    assert state["login"] == 1
+    assert client._token == "FRESH_TOKEN"

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -2,12 +2,14 @@
 
 server.py is imported by the console entry point, so an import-time failure
 takes the whole server down before it serves a request -- and nothing else in
-the suite imports it.
+the suite imports it. Issue #37 was exactly that: an SDK major bump moved the
+server class, and the crash only surfaced at startup.
 """
 
 from __future__ import annotations
 
 import asyncio
+import threading
 
 EXPECTED_TOOLS = {
     "add_custom_food",
@@ -41,6 +43,26 @@ def test_server_identity():
     assert mcp.name == "cronometer"
 
 
+def test_server_is_mcpserver_instance():
+    """Pins the SDK 2.x server class: 1.x's FastMCP no longer exists."""
+    from mcp.server.mcpserver import MCPServer
+
+    from cronometer_api_mcp.server import mcp
+
+    assert isinstance(mcp, MCPServer)
+
+
+def test_server_reports_a_version():
+    """serverInfo.version must not be empty.
+
+    SDK 2.x reports "" when `version=` is omitted, so the mistake is invisible
+    until a client displays it.
+    """
+    from cronometer_api_mcp.server import _server_version
+
+    assert _server_version()
+
+
 def test_registered_tools():
     """Tools register as an import side effect of the @mcp.tool() decorators.
 
@@ -56,6 +78,21 @@ def test_registered_tools():
         assert tool.description, f"{tool.name} has no description"
 
 
+def test_tool_annotations_survive_schema_coercion():
+    """The read-only hints must reach the wire model.
+
+    They are declared in camelCase (`readOnlyHint`), which SDK 2.x accepts only
+    as an input alias for the snake_case attributes. A silent coercion failure
+    would strip the hints clients use to decide what is safe to call.
+    """
+    from cronometer_api_mcp.server import mcp
+
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    assert tools["get_food_log"].annotations.read_only_hint is True
+    assert tools["add_food_entry"].annotations.read_only_hint is False
+
+
 def test_no_client_constructed_at_import():
     """Import must not need credentials or touch the network.
 
@@ -65,3 +102,39 @@ def test_no_client_constructed_at_import():
     from cronometer_api_mcp import server
 
     assert server._client is None
+
+
+def test_concurrent_get_client_builds_one_instance(monkeypatch):
+    """SDK 2.x runs sync tools on worker threads, so _get_client() races.
+
+    Two clients would mean two logins against a rate-limited endpoint (#3) and
+    two writers for one session file.
+    """
+    from cronometer_api_mcp import server
+
+    monkeypatch.setattr(server, "_client", None)
+
+    built = []
+    threads_n = 8
+    start = threading.Barrier(threads_n)
+
+    class FakeClient:
+        def __init__(self) -> None:
+            built.append(self)
+
+    monkeypatch.setattr(server, "CronometerClient", FakeClient)
+
+    seen = []
+
+    def worker() -> None:
+        start.wait()
+        seen.append(server._get_client())
+
+    threads = [threading.Thread(target=worker) for _ in range(threads_n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(built) == 1
+    assert {id(c) for c in seen} == {id(built[0])}

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.29.0,<2" },
+    { name = "mcp", specifier = ">=2.0.0,<3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "tzdata", specifier = ">=2024.1" },
 ]
@@ -202,6 +202,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -222,21 +235,37 @@ socks = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -277,15 +306,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -295,9 +324,34 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -379,20 +433,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
     { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.13.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
 ]
 
 [[package]]
@@ -569,6 +609,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
2.x deleted mcp.server.fastmcp, so server.py imports MCPServer from mcp.server.mcpserver and the pin becomes >=2.0.0,<3. httpx stays declared for us alone since 2.x moved to httpx2.

2.x also runs sync tool handlers on worker threads, where 1.x serialized them, so all 15 tools now share the client and its auth state concurrently. Guard both lazy inits with double-checked locks, serialize auth state and its session file under an RLock, and re-authenticate only against the token the request actually sent -- a burst now does one login instead of one per thread against the rate-limited endpoint.