### PR TITLE
Add recipe import from free-text ingredient lists (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ cached session, so it also overrides a stale cached timezone.
 | `add_food_entry` | Log a food serving to the diary |
 | `remove_food_entry` | Remove one or more diary entries |
 | `add_custom_food` | Create a custom food with specified nutrition |
+| `add_recipe` | Create a recipe from existing foods referenced by ID and gram weight |
+| `import_recipe` | Create a recipe from a free-text ingredient list; Cronometer matches each line to a database food and converts the amount to grams |
 | `copy_day` | Copy all entries from the previous day |
 | `mark_day_complete` | Mark a diary day as complete or incomplete |
 
@@ -165,6 +167,8 @@ The API uses two protocols:
 - **v2 (`POST /api/v2/*`)** -- JSON-body auth, used for most operations (food search, diary read/write, nutrition, fasting, macros, biometrics)
 - **v3 (`DELETE /api/v3/user/{id}/*`)** -- Header-based auth (`x-crono-session`), used for diary entry deletion
 
+Recipe import is the one asynchronous operation: `import_recipe` returns a job id, and `poll_async_result` is polled until the server reports 100% progress and attaches the parsed ingredients.
+
 ## Python API
 
 You can use the client directly:
@@ -190,6 +194,13 @@ client.add_serving(
 
 # Get today's diary
 diary = client.get_diary()
+
+# Import a recipe from a free-text ingredient list
+recipe = client.import_recipe("one hot dog\nketchup\nbun")
+print(recipe["food_id"], recipe["ingredients"])
+
+# Parse without saving, to review the matches first
+preview = client.import_recipe("2 tbsp olive oil\n200g chicken", save=False)
 
 # Get nutrition scores
 scores = client.get_nutrition_scores()

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import threading
+import time
 from datetime import date, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -106,6 +107,13 @@ SUMMARY_MACRO_IDS = {
     "fiber": 291,
     "alcohol": 221,
 }
+
+# Recipe import is the API's one async job: import_recipe returns a future id,
+# poll_async_result is polled until it attaches a `result`.
+_IMPORT_RECIPE_ENDPOINT = "/api/v2/import_recipe"
+_POLL_ASYNC_ENDPOINT = "/api/v2/poll_async_result"
+_RECIPE_RESULT_TYPE = "recipe"
+_IMPORT_COMPLETE_PROGRESS = 100
 
 
 class CronometerError(Exception):
@@ -854,6 +862,188 @@ class CronometerClient:
             "total_grams": total_grams,
             "ingredient_count": len(ingredient_rows),
         }
+
+    # ------------------------------------------------------------------
+    # Recipe import (free-text ingredients)
+    # ------------------------------------------------------------------
+
+    def import_recipe(
+        self,
+        ingredients_text: str,
+        *,
+        name: str | None = None,
+        save: bool = True,
+        poll_interval: float = 1.0,
+        timeout: float = 60.0,
+    ) -> dict:
+        """Import a recipe from a free-text ingredient list.
+
+        The app's "Import Recipe" feature. Where create_recipe needs a food ID
+        and gram weight per ingredient, this hands raw lines ("2 tbsp ketchup")
+        to Cronometer's parser, which does the food matching and unit-to-gram
+        conversion. Matching is fuzzy, so callers should review the results.
+
+        The import is async: the server returns a future id which this polls
+        until complete. Matches are then saved via create_recipe.
+
+        Args:
+            ingredients_text: Ingredient lines separated by newlines.
+            name: Recipe name. Defaults to the server-generated one.
+            save: When False, parse only and skip persistence.
+            poll_interval: Seconds between poll attempts.
+            timeout: Give up after this many seconds of polling.
+
+        Returns "recipe_name", "ingredients" (usable matches), and "unmatched".
+        When save=True, also create_recipe's "food_id", "total_grams", and
+        "ingredient_count".
+        """
+        if not ingredients_text or not ingredients_text.strip():
+            raise ValueError("import_recipe requires at least one ingredient line")
+
+        started = self._start_recipe_import(ingredients_text)
+        result = self._await_async_result(
+            started,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+
+        recipe = result.get("recipe") or {}
+        recipe_name = name or recipe.get("name") or "Imported recipe"
+
+        matched, unmatched = self._split_import_entries(result.get("entries") or [])
+
+        out: dict = {
+            "recipe_name": recipe_name,
+            "ingredients": matched,
+            "unmatched": unmatched,
+        }
+        if not save:
+            return out
+
+        if not matched:
+            raise CronometerError(
+                "Recipe import matched no usable ingredients; "
+                f"unresolved lines: {[u['raw_text'] for u in unmatched]}"
+            )
+
+        created = self.create_recipe(
+            recipe_name,
+            ingredients=[(m["food_id"], m["grams"], m["measure_id"]) for m in matched],
+        )
+        return out | created
+
+    def _start_recipe_import(self, ingredients_text: str) -> dict:
+        """Kick off an async recipe import and return the initial job state."""
+        payload = {
+            # An empty url means "parse the text"; the app sends both fields.
+            "url": "",
+            "ingredients": ingredients_text,
+            "enable_async": True,
+            "config": {"call_version": 1},
+        }
+        data = self._request(_IMPORT_RECIPE_ENDPOINT, payload)
+        self._raise_if_job_failed(data, "start recipe import")
+
+        if not data.get("id"):
+            raise CronometerError(f"Recipe import returned no job id: {data}")
+
+        logger.info("Started recipe import (job=%s)", data["id"])
+        return data
+
+    def _await_async_result(
+        self,
+        started: dict,
+        *,
+        poll_interval: float,
+        timeout: float,
+    ) -> dict:
+        """Poll an async job until it attaches a result, or fail loudly.
+
+        Small imports can complete on the initial response, so it's checked
+        before the first sleep.
+        """
+        future_id = started["id"]
+        data = started
+        deadline = time.monotonic() + timeout
+
+        while True:
+            result = data.get("result")
+            if result:
+                logger.info("Recipe import job %s completed", future_id)
+                return result
+
+            # 100% can arrive on the same response as the result, so only
+            # "done but empty" is an error.
+            if data.get("progress") == _IMPORT_COMPLETE_PROGRESS:
+                raise CronometerError(
+                    f"Recipe import job {future_id} finished without a result: {data}"
+                )
+
+            if time.monotonic() >= deadline:
+                raise CronometerError(
+                    f"Recipe import job {future_id} did not finish within "
+                    f"{timeout:g}s (last progress: {data.get('progress')!r}, "
+                    f"{data.get('message')!r})"
+                )
+
+            time.sleep(poll_interval)
+            data = self._request(
+                _POLL_ASYNC_ENDPOINT,
+                {
+                    "futureId": future_id,
+                    "resultType": _RECIPE_RESULT_TYPE,
+                    "config": {"call_version": 1},
+                },
+            )
+            self._raise_if_job_failed(data, f"poll recipe import job {future_id}")
+            logger.debug(
+                "Recipe import %s: %s%% %s",
+                future_id,
+                data.get("progress"),
+                data.get("message"),
+            )
+
+    @staticmethod
+    def _raise_if_job_failed(data: dict, action: str) -> None:
+        """Async endpoints signal failure with isError plus a message."""
+        if data.get("isError"):
+            message = data.get("message") or data.get("messages") or data
+            raise CronometerError(f"Failed to {action}: {message}")
+
+    @staticmethod
+    def _split_import_entries(entries: list) -> tuple[list[dict], list[dict]]:
+        """Split parser entries into usable matches and unresolved lines.
+
+        Entries with no food or a non-positive weight are held back, since
+        create_recipe's gram validation would reject the whole batch.
+        """
+        matched: list[dict] = []
+        unmatched: list[dict] = []
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            ingredient = entry.get("ingredient") or {}
+            food_id = ingredient.get("foodId")
+            grams = ingredient.get("grams")
+            row = {
+                "raw_text": entry.get("rawIngredientImport"),
+                "description": entry.get("description"),
+                "food_id": food_id,
+                "measure_id": ingredient.get("measureId"),
+                "grams": grams,
+                # False when the server couldn't map the stated unit onto a
+                # real serving size and guessed.
+                "serving_size_match": entry.get("servingSizeMatchFound"),
+                "alternate_food_ids": entry.get("topKFoodIds") or [],
+            }
+
+            if food_id and isinstance(grams, (int, float)) and grams > 0:
+                matched.append(row)
+            else:
+                unmatched.append(row)
+
+        return matched, unmatched
 
     # ------------------------------------------------------------------
     # Diary: add serving

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -688,6 +688,61 @@ def add_recipe(
         return _err(e)
 
 
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    }
+)
+def import_recipe(ingredients: str, name: str | None = None) -> str:
+    """Create a recipe from a free-text ingredient list.
+
+    Cronometer's "Import Recipe" feature: pass ingredients as plain text, one
+    per line, and the server matches each to a food and converts the amount to
+    grams. No need to call search_foods first.
+
+    Prefer this when the user describes ingredients in their own words. Use
+    add_recipe instead when you have exact food_ids and gram weights -- e.g. the
+    user confirmed specific foods from search_foods results.
+
+    Matching is fuzzy, so report the returned matches back to the user for
+    confirmation. Unresolved lines are listed under "unmatched" and excluded
+    from the recipe. This saves to My Foods; use add_food_entry to log it.
+
+    Args:
+        ingredients: Ingredient lines separated by newlines, e.g.
+            "2 tbsp olive oil\\n200g chicken". Include quantities where known,
+            since bare names can match surprising amounts.
+        name: Recipe name. Defaults to a server-generated one.
+    """
+    try:
+        client = _get_client()
+        result = client.import_recipe(ingredients, name=name)
+
+        # Fetch back to get the server-assigned measure_id
+        food_data = client.get_food(result["food_id"])
+        return _ok(
+            {
+                "food_id": result["food_id"],
+                "measure_id": food_data.get("defaultMeasureId"),
+                "name": result["recipe_name"],
+                "total_grams": result["total_grams"],
+                "ingredient_count": result["ingredient_count"],
+                "ingredients": result["ingredients"],
+                "unmatched": result["unmatched"],
+                "note": (
+                    "Matching is automatic -- show the ingredients list to the "
+                    "user to confirm. Use food_id and measure_id with "
+                    "add_food_entry to log this recipe."
+                ),
+            }
+        )
+    except Exception as e:
+        return _err(e)
+
+
 # ------------------------------------------------------------------
 # Macro targets
 # ------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -476,6 +476,355 @@ def test_create_recipe_missing_ingredient_food_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# import_recipe
+#
+# Async flow: import_recipe returns a future id, poll_async_result is polled
+# until it attaches a result, then matches are saved via add_food. Fixtures are
+# the real bodies captured from the app for "one hot dog\nketchup\nbun".
+# Verified against the live API (food 81033679).
+# ---------------------------------------------------------------------------
+
+IMPORT_JOB_ID = "69326e05-6f0e-4227-bd13-7a21e0fee9d6"
+
+IMPORT_STARTED = {
+    "isError": False,
+    "progress": 0,
+    "messages": [],
+    "id": IMPORT_JOB_ID,
+    "message": "Preparing your recipe for import.",
+    "userId": 6407976,
+}
+
+IMPORT_IN_PROGRESS = {
+    "isError": False,
+    "progress": 10,
+    "messages": [],
+    "id": IMPORT_JOB_ID,
+    "message": "Searching our database for the ingredients...",
+    "userId": 6407976,
+}
+
+
+def _import_entry(raw, description, food_id, measure_id, grams, top_k):
+    return {
+        "amountSearchString": "Optional[1.0]",
+        "unitSearchString": "",
+        "ingredient": {
+            "measureId": measure_id,
+            "translationId": 0,
+            "foodId": food_id,
+            "id": 0,
+            "grams": grams,
+            "value": grams,
+        },
+        "rawIngredientImport": raw,
+        "description": description,
+        "topKFoodIds": top_k,
+        "servingSizeMatchFound": True,
+    }
+
+
+IMPORT_ENTRIES = [
+    _import_entry(
+        "one hot dog", "hot dog", 4572, 12695, 45, [4572, 449773, 459646, 461995]
+    ),
+    _import_entry("ketchup", "ketchup", 449782, 992859, 1, [449782, 11239521, 4387294]),
+    _import_entry("bun", "bun", 456806, 1030841, 43, [456806, 461989, 33638819]),
+]
+
+IMPORT_COMPLETE = {
+    "result": {
+        "entries": IMPORT_ENTRIES,
+        "recipe": {
+            "name": "Classic Hot Dog Bun",
+            "id": 0,
+            "ingredients": [e["ingredient"] for e in IMPORT_ENTRIES],
+        },
+    },
+    "isError": False,
+    "progress": 100,
+    "messages": [],
+    "id": IMPORT_JOB_ID,
+    "message": "Finishing Up",
+    "userId": 6407976,
+}
+
+# Ingredient foods the saved recipe resolves against, keyed to the captured IDs.
+IMPORT_INGREDIENT_FOODS = [
+    {
+        "id": 4572,
+        "name": "Hot Dog",
+        "measures": [{"id": 12695, "name": "g", "value": 1, "type": "Weight"}],
+        "nutrients": [{"id": 208, "amount": 290.0}],
+    },
+    {
+        "id": 449782,
+        "name": "Ketchup",
+        "measures": [{"id": 992859, "name": "g", "value": 1, "type": "Weight"}],
+        "nutrients": [{"id": 208, "amount": 100.0}],
+    },
+    {
+        "id": 456806,
+        "name": "Bun",
+        "measures": [{"id": 1030841, "name": "g", "value": 1, "type": "Weight"}],
+        "nutrients": [{"id": 208, "amount": 280.0}],
+    },
+]
+
+
+def _import_client(tmp_path: Path, monkeypatch, poll_bodies):
+    """Client whose async-job endpoints replay `poll_bodies` in order.
+
+    Routes by endpoint so the trailing add_food save is recorded separately
+    from polling traffic. time.sleep is neutered to keep the loop instant.
+    """
+    monkeypatch.setattr("cronometer_api_mcp.client.time.sleep", lambda _s: None)
+
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    client._user_id = 42
+    client._token = "TOKEN"
+    client.get_foods = lambda ids: IMPORT_INGREDIENT_FOODS  # type: ignore[method-assign]
+
+    state = {"calls": [], "polls": 0, "add_food": []}
+    remaining = list(poll_bodies)
+
+    def fake_post(endpoint, json=None):
+        state["calls"].append(endpoint)
+        if endpoint == "/api/v2/add_food":
+            state["add_food"].append(json)
+            return FakeResp({"result": "SUCCESS", "id": 76533895})
+        if endpoint in ("/api/v2/import_recipe", "/api/v2/poll_async_result"):
+            if endpoint == "/api/v2/poll_async_result":
+                state["polls"] += 1
+            return FakeResp(remaining.pop(0) if remaining else poll_bodies[-1])
+        raise AssertionError(f"unexpected endpoint {endpoint}")
+
+    client._http.post = fake_post  # type: ignore[method-assign]
+    return client, state
+
+
+def test_import_recipe_parses_polls_and_saves(tmp_path, monkeypatch):
+    """Happy path: start, poll past an in-progress tick, then save the match."""
+    client, state = _import_client(
+        tmp_path,
+        monkeypatch,
+        [IMPORT_STARTED, IMPORT_IN_PROGRESS, IMPORT_COMPLETE],
+    )
+
+    result = client.import_recipe("one hot dog\nketchup\nbun")
+
+    # Name comes from the server when the caller doesn't supply one.
+    assert result["recipe_name"] == "Classic Hot Dog Bun"
+    assert result["food_id"] == 76533895
+    assert result["ingredient_count"] == 3
+    assert result["total_grams"] == 89.0  # 45 + 1 + 43
+    assert result["unmatched"] == []
+
+    started = state["calls"][0]
+    assert started == "/api/v2/import_recipe"
+    assert state["polls"] == 2
+
+    # One save, carrying the parser's food/measure/gram triples.
+    assert len(state["add_food"]) == 1
+    ingredients = state["add_food"][0]["data"]["ingredients"]
+    assert [(i["foodId"], i["measureId"], i["grams"]) for i in ingredients] == [
+        (4572, 12695, 45.0),
+        (449782, 992859, 1.0),
+        (456806, 1030841, 43.0),
+    ]
+
+    # Matches are reported back for review, alternates included.
+    assert result["ingredients"][0]["raw_text"] == "one hot dog"
+    assert result["ingredients"][0]["description"] == "hot dog"
+    assert result["ingredients"][0]["alternate_food_ids"] == [
+        4572,
+        449773,
+        459646,
+        461995,
+    ]
+
+
+def test_import_recipe_sends_expected_payloads(tmp_path, monkeypatch):
+    """Request bodies match the captured app traffic."""
+    client, _state = _import_client(
+        tmp_path, monkeypatch, [IMPORT_STARTED, IMPORT_COMPLETE]
+    )
+    sent = []
+    inner = client._http.post
+
+    def recording_post(endpoint, json=None):
+        sent.append((endpoint, json))
+        return inner(endpoint, json=json)
+
+    client._http.post = recording_post  # type: ignore[method-assign]
+
+    client.import_recipe("one hot dog\nketchup\nbun")
+
+    _, start_body = sent[0]
+    assert start_body["url"] == ""
+    assert start_body["ingredients"] == "one hot dog\nketchup\nbun"
+    assert start_body["enable_async"] is True
+
+    _, poll_body = sent[1]
+    assert poll_body["futureId"] == IMPORT_JOB_ID
+    assert poll_body["resultType"] == "recipe"
+
+
+def test_import_recipe_save_false_skips_persistence(tmp_path, monkeypatch):
+    """Parse-only mode returns matches without creating a food."""
+    client, state = _import_client(
+        tmp_path, monkeypatch, [IMPORT_STARTED, IMPORT_COMPLETE]
+    )
+
+    result = client.import_recipe("one hot dog\nketchup\nbun", save=False)
+
+    assert state["add_food"] == []
+    assert "food_id" not in result
+    assert len(result["ingredients"]) == 3
+
+
+def test_import_recipe_explicit_name_overrides_server_name(tmp_path, monkeypatch):
+    client, state = _import_client(
+        tmp_path, monkeypatch, [IMPORT_STARTED, IMPORT_COMPLETE]
+    )
+
+    result = client.import_recipe("one hot dog\nketchup\nbun", name="Ballpark Dog")
+
+    assert result["recipe_name"] == "Ballpark Dog"
+    assert state["add_food"][0]["data"]["name"] == "Ballpark Dog"
+
+
+def test_import_recipe_result_on_first_response_skips_polling(tmp_path, monkeypatch):
+    """A job that finishes immediately needs no poll round trip."""
+    immediate = IMPORT_STARTED | {
+        "progress": 100,
+        "result": IMPORT_COMPLETE["result"],
+    }
+    client, state = _import_client(tmp_path, monkeypatch, [immediate])
+
+    result = client.import_recipe("one hot dog")
+
+    assert state["polls"] == 0
+    assert result["food_id"] == 76533895
+
+
+def test_import_recipe_server_error_raises(tmp_path, monkeypatch):
+    """isError on the kickoff response fails loudly and saves nothing."""
+    failed = {
+        "isError": True,
+        "progress": 0,
+        "id": IMPORT_JOB_ID,
+        "message": "Could not parse those ingredients.",
+    }
+    client, state = _import_client(tmp_path, monkeypatch, [failed])
+
+    with pytest.raises(CronometerError, match="Could not parse those ingredients"):
+        client.import_recipe("asdfgh")
+
+    assert state["add_food"] == []
+
+
+def test_import_recipe_poll_error_raises(tmp_path, monkeypatch):
+    """isError surfacing mid-poll aborts the import."""
+    failed = {"isError": True, "id": IMPORT_JOB_ID, "message": "Import failed"}
+    client, state = _import_client(tmp_path, monkeypatch, [IMPORT_STARTED, failed])
+
+    with pytest.raises(CronometerError, match="Import failed"):
+        client.import_recipe("one hot dog")
+
+    assert state["add_food"] == []
+
+
+def test_import_recipe_times_out(tmp_path, monkeypatch):
+    """A job that never completes raises rather than polling forever."""
+    client, state = _import_client(
+        tmp_path, monkeypatch, [IMPORT_STARTED, IMPORT_IN_PROGRESS]
+    )
+
+    # Advance the clock a minute per reading so the deadline trips quickly.
+    ticks = iter(range(0, 10_000, 60))
+    monkeypatch.setattr(
+        "cronometer_api_mcp.client.time.monotonic", lambda: float(next(ticks))
+    )
+
+    with pytest.raises(CronometerError, match="did not finish within"):
+        client.import_recipe("one hot dog", timeout=30.0)
+
+    assert state["add_food"] == []
+
+
+def test_import_recipe_finished_without_result_raises(tmp_path, monkeypatch):
+    """100% progress with no payload is a server bug, not a silent success."""
+    empty = {"isError": False, "progress": 100, "id": IMPORT_JOB_ID, "messages": []}
+    client, state = _import_client(tmp_path, monkeypatch, [IMPORT_STARTED, empty])
+
+    with pytest.raises(CronometerError, match="without a result"):
+        client.import_recipe("one hot dog")
+
+    assert state["add_food"] == []
+
+
+def test_import_recipe_separates_unmatched_lines(tmp_path, monkeypatch):
+    """Unresolvable lines are reported, not fed to create_recipe."""
+    partial = {
+        "isError": False,
+        "progress": 100,
+        "id": IMPORT_JOB_ID,
+        "result": {
+            "recipe": {"name": "Partial Recipe"},
+            "entries": [
+                IMPORT_ENTRIES[0],
+                # No food matched.
+                _import_entry("a pinch of unobtainium", "unobtainium", 0, 0, 0, []),
+                # Matched a food but weighed nothing.
+                _import_entry("air", "air", 999, 111, 0, [999]),
+            ],
+        },
+    }
+    client, state = _import_client(tmp_path, monkeypatch, [IMPORT_STARTED, partial])
+
+    result = client.import_recipe("one hot dog\na pinch of unobtainium\nair")
+
+    assert [i["raw_text"] for i in result["ingredients"]] == ["one hot dog"]
+    assert [u["raw_text"] for u in result["unmatched"]] == [
+        "a pinch of unobtainium",
+        "air",
+    ]
+    # Only the usable line reaches the save.
+    saved = state["add_food"][0]["data"]["ingredients"]
+    assert [i["foodId"] for i in saved] == [4572]
+
+
+def test_import_recipe_all_unmatched_raises(tmp_path, monkeypatch):
+    """Nothing usable means no empty recipe gets created."""
+    nothing = {
+        "isError": False,
+        "progress": 100,
+        "id": IMPORT_JOB_ID,
+        "result": {
+            "recipe": {"name": "Empty"},
+            "entries": [_import_entry("unobtainium", "unobtainium", 0, 0, 0, [])],
+        },
+    }
+    client, state = _import_client(tmp_path, monkeypatch, [IMPORT_STARTED, nothing])
+
+    with pytest.raises(CronometerError, match="no usable ingredients"):
+        client.import_recipe("unobtainium")
+
+    assert state["add_food"] == []
+
+
+def test_import_recipe_rejects_blank_input(tmp_path, monkeypatch):
+    """Validation happens before any network call."""
+    client, state = _import_client(tmp_path, monkeypatch, [IMPORT_STARTED])
+
+    with pytest.raises(ValueError):
+        client.import_recipe("   \n  ")
+
+    assert state["calls"] == []
+
+
+# ---------------------------------------------------------------------------
 # create_custom_food: extra_nutrients
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -24,6 +24,7 @@ EXPECTED_TOOLS = {
     "get_food_log",
     "get_macro_targets",
     "get_nutrition_scores",
+    "import_recipe",
     "list_biometrics",
     "mark_day_complete",
     "remove_food_entry",


### PR DESCRIPTION
Mirrors the app's "Import Recipe": ingredient lines are handed to Cronometer's parser, which matches each to a database food and converts stated amounts to grams, so callers don't need food IDs up front.

The import is the API's one async job -- import_recipe returns a future id and poll_async_result is polled until it attaches a result. Matched ingredients are then persisted through the existing create_recipe path. Lines the parser can't resolve are reported separately instead of failing the whole batch on create_recipe's gram validation.