### PR TITLE
Add optional TOTP support for accounts with two-factor authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ CRONOMETER_USERNAME=
 CRONOMETER_PASSWORD=
 # Only for accounts with two-factor authentication: the base32 key shown at 2FA setup
 CRONOMETER_TOTP_SECRET=
+# Optional IANA timezone override, for example America/Los_Angeles
+CRONOMETER_ACCOUNT_TZ=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 CRONOMETER_USERNAME=
 CRONOMETER_PASSWORD=
+# Only for accounts with two-factor authentication: the base32 key shown at 2FA setup
+CRONOMETER_TOTP_SECRET=

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ cached session, so it also overrides a stale cached timezone.
       "command": ["uvx", "cronometer-api-mcp"],
       "environment": {
         "CRONOMETER_USERNAME": "{env:CRONOMETER_USERNAME}",
-        "CRONOMETER_PASSWORD": "{env:CRONOMETER_PASSWORD}"
+        "CRONOMETER_PASSWORD": "{env:CRONOMETER_PASSWORD}",
+        "CRONOMETER_TOTP_SECRET": "{env:CRONOMETER_TOTP_SECRET}",
+        "CRONOMETER_ACCOUNT_TZ": "{env:CRONOMETER_ACCOUNT_TZ}"
       },
       "enabled": true
     }
@@ -100,7 +102,9 @@ cached session, so it also overrides a stale cached timezone.
       "args": ["cronometer-api-mcp"],
       "env": {
         "CRONOMETER_USERNAME": "your@email.com",
-        "CRONOMETER_PASSWORD": "your-password"
+        "CRONOMETER_PASSWORD": "your-password",
+        "CRONOMETER_TOTP_SECRET": "your-base32-key",
+        "CRONOMETER_ACCOUNT_TZ": "America/Los_Angeles"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ export CRONOMETER_USERNAME="your@email.com"
 export CRONOMETER_PASSWORD="your-password"
 ```
 
+#### Optional: two-factor authentication
+
+If the account has two-factor authentication enabled, `/api/v2/login`
+answers `TOTP_CODE_REQUIRED` unless the request carries the current 6-digit
+code. Give the server the base32 key that Cronometer showed when 2FA was set
+up (the same key you scanned into your authenticator app) and it derives the
+code itself at every login (RFC 6238, SHA-1, 30 s period):
+
+```bash
+export CRONOMETER_TOTP_SECRET="ABCD EFGH IJKL MNOP QRST UVWX YZ23 4567"
+```
+
+Spaces and lowercase are fine. Leave it unset for accounts without 2FA.
+
 #### Optional: override the account timezone
 
 Diary entries are stamped in your Cronometer account's timezone, which the

--- a/server.json
+++ b/server.json
@@ -27,6 +27,18 @@
           "description": "Your Cronometer account password",
           "isRequired": true,
           "isSecret": true
+        },
+        {
+          "name": "CRONOMETER_TOTP_SECRET",
+          "description": "Base32 key for accounts with two-factor authentication",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "CRONOMETER_ACCOUNT_TZ",
+          "description": "Optional IANA timezone override, for example America/Los_Angeles",
+          "isRequired": false,
+          "isSecret": false
         }
       ]
     }

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -9,9 +9,13 @@ Frida-based traffic capture that established the auth flow and initial
 endpoints.
 """
 
+import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
+import struct
 import threading
 import time
 from datetime import date, datetime
@@ -118,6 +122,23 @@ _IMPORT_COMPLETE_PROGRESS = 100
 
 class CronometerError(Exception):
     """Raised when a Cronometer API call fails."""
+
+
+def _totp_code(secret: str, for_time: float | None = None) -> str:
+    """Current RFC 6238 TOTP code (SHA-1, 30 s period, 6 digits) for `secret`.
+
+    `secret` is the base32 key shown by Cronometer when enabling two-factor
+    authentication; authenticator apps display it grouped and sometimes
+    lowercased, so whitespace and case are normalized before decoding.
+    """
+    normalized = "".join(secret.split()).upper()
+    normalized += "=" * (-len(normalized) % 8)
+    key = base64.b32decode(normalized)
+    counter = int((time.time() if for_time is None else for_time) // 30)
+    digest = hmac.new(key, struct.pack(">Q", counter), hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    code = int.from_bytes(digest[offset : offset + 4], "big") & 0x7FFFFFFF
+    return f"{code % 1_000_000:06d}"
 
 
 class CronometerClient:
@@ -251,6 +272,11 @@ class CronometerClient:
             )
         return username, password
 
+    @staticmethod
+    def _totp_user_code() -> str | None:
+        secret = os.getenv("CRONOMETER_TOTP_SECRET")
+        return _totp_code(secret) if secret else None
+
     def login(self) -> None:
         """Authenticate with Cronometer and cache the session token.
 
@@ -271,7 +297,9 @@ class CronometerClient:
             # leaves the account setting untouched and the response echoes the
             # account's real zone.
             "timezone": None,
-            "userCode": None,
+            # 6-digit TOTP code for accounts with two-factor authentication,
+            # derived from CRONOMETER_TOTP_SECRET; null when 2FA is not in use.
+            "userCode": self._totp_user_code(),
             "build": "4.48.2 b2807-a",
             "device": "Android 14 (SDK 34), Google Pixel 6 Pro",
             "firebaseToken": "",
@@ -295,6 +323,12 @@ class CronometerClient:
             data = resp.json()
 
             if data.get("result") != "SUCCESS" and "sessionKey" not in data:
+                if data.get("error") == "TOTP_CODE_REQUIRED":
+                    raise CronometerError(
+                        "Login failed: the account has two-factor authentication "
+                        "enabled; set CRONOMETER_TOTP_SECRET to the base32 key "
+                        "shown when 2FA was set up"
+                    )
                 raise CronometerError(f"Login failed: {data}")
 
             self._user_id = data["id"]

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -1,0 +1,107 @@
+"""Tests for optional TOTP (two-factor) support at login.
+
+Accounts with two-factor authentication enabled get `{"result": "FAIL",
+"error": "TOTP_CODE_REQUIRED"}` from /api/v2/login unless the request carries
+the current 6-digit code in `userCode`. When CRONOMETER_TOTP_SECRET is set the
+client derives that code itself (RFC 6238, SHA-1, 30 s period, 6 digits).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cronometer_api_mcp.client import CronometerClient, CronometerError, _totp_code
+
+# RFC 6238 Appendix B test vectors (SHA-1). The secret is the ASCII string
+# "12345678901234567890"; the 6-digit codes are the last six digits of the
+# 8-digit values listed in the RFC.
+RFC6238_SECRET_B32 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+RFC6238_VECTORS = [
+    (59, "287082"),
+    (1111111109, "081804"),
+    (1234567890, "005924"),
+    (2000000000, "279037"),
+]
+
+SUCCESS_BODY = {
+    "result": "SUCCESS",
+    "id": 123,
+    "sessionKey": "TOKEN",
+    "timezone": "UTC",
+}
+TOTP_REQUIRED_BODY = {"result": "FAIL", "error": "TOTP_CODE_REQUIRED"}
+
+
+class FakeResp:
+    def __init__(self, body) -> None:
+        self._body = body
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def json(self):
+        return self._body
+
+
+def make_client(tmp_path: Path, body: dict):
+    """Client whose login POST is captured and answered with `body`."""
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    captured: dict = {}
+
+    def fake_post(endpoint, json=None):
+        captured["endpoint"] = endpoint
+        captured["payload"] = json
+        return FakeResp(body)
+
+    client._http.post = fake_post  # type: ignore[method-assign]
+    return client, captured
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    monkeypatch.setenv("CRONOMETER_USERNAME", "user@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "secret")
+    monkeypatch.delenv("CRONOMETER_TOTP_SECRET", raising=False)
+
+
+@pytest.mark.parametrize(("at", "expected"), RFC6238_VECTORS)
+def test_totp_code_matches_rfc6238_sha1_vectors(at, expected):
+    assert _totp_code(RFC6238_SECRET_B32, at) == expected
+
+
+def test_totp_code_accepts_lowercase_and_spaced_secret():
+    """Authenticator apps display the key grouped and sometimes lowercased."""
+    spaced = "gezd gnbv gy3t qojq gezd gnbv gy3t qojq"
+    assert _totp_code(spaced, 59) == "287082"
+
+
+def test_login_sends_null_user_code_without_secret(credentials, tmp_path):
+    client, captured = make_client(tmp_path, SUCCESS_BODY)
+
+    client.login()
+
+    assert captured["endpoint"] == "/api/v2/login"
+    assert captured["payload"]["userCode"] is None
+
+
+def test_login_sends_current_totp_code_when_secret_set(
+    credentials, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("CRONOMETER_TOTP_SECRET", RFC6238_SECRET_B32)
+    client, captured = make_client(tmp_path, SUCCESS_BODY)
+
+    client.login()
+
+    code = captured["payload"]["userCode"]
+    assert isinstance(code, str) and len(code) == 6 and code.isdigit()
+    assert code == _totp_code(RFC6238_SECRET_B32)
+
+
+def test_login_totp_required_without_secret_points_at_env_var(credentials, tmp_path):
+    client, _ = make_client(tmp_path, TOTP_REQUIRED_BODY)
+
+    with pytest.raises(CronometerError, match="CRONOMETER_TOTP_SECRET"):
+        client.login()


### PR DESCRIPTION
Accounts with two-factor authentication enabled get `{"result": "FAIL", "error": "TOTP_CODE_REQUIRED"}` from `/api/v2/login`. Sending the current 6-digit code in the existing `userCode` field makes the same request succeed (verified against the live API on 2026-09-02).

- New optional env var `CRONOMETER_TOTP_SECRET`: the base32 key shown at 2FA setup (the same key scanned into the authenticator app). When set, the client derives the code at login (RFC 6238, SHA-1, 30 s period, 6 digits) with the standard library only; whitespace and case in the key are normalized.
- Without the secret the payload is unchanged (`userCode: null`), and a `TOTP_CODE_REQUIRED` failure now names the env var to set instead of dumping the raw body.
- Tests: RFC 6238 Appendix B vectors, login payload with and without the secret, and the error hint. README and `.env.example` updated.