### PR TITLE
Add update_custom_food and delete_custom_food tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ cached session, so it also overrides a stale cached timezone.
 | `add_food_entry` | Log a food serving to the diary |
 | `remove_food_entry` | Remove one or more diary entries |
 | `add_custom_food` | Create a custom food with specified nutrition |
+| `update_custom_food` | Edit a custom food in place: name, nutrition, or serving size |
+| `delete_custom_food` | Retire a custom food so it leaves search and the Custom Foods list (existing diary entries are kept) |
 | `add_recipe` | Create a recipe from existing foods referenced by ID and gram weight |
 | `import_recipe` | Create a recipe from a free-text ingredient list; Cronometer matches each line to a database food and converts the amount to grams |
 | `copy_day` | Copy all entries from the previous day |

--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -10,6 +10,7 @@ endpoints.
 """
 
 import base64
+import copy
 import hashlib
 import hmac
 import json
@@ -722,6 +723,166 @@ class CronometerClient:
 
         logger.info("Created custom food %r (id=%d)", name, food_id)
         return {"food_id": food_id, "measure_id": None}
+
+    # ------------------------------------------------------------------
+    # Custom food edit / retire
+    # ------------------------------------------------------------------
+
+    def _save_custom_food(self, food: dict) -> dict:
+        """Re-send a full food object to /api/v2/add_food, which upserts.
+
+        A non-zero id edits that food in place (verified against the live API:
+        the id, measure ids and unchanged nutrients all survive). The server
+        tacks FOOD_CHANGED sync messages onto get_food responses; those are not
+        food data and are dropped before sending.
+        """
+        data = copy.deepcopy(food)
+        data.pop("messages", None)
+        payload = {"data": data, "config": {"call_version": 1}}
+        resp = self._request("/api/v2/add_food", payload)
+        if resp.get("id") != data["id"]:
+            raise CronometerError(f"Failed to save custom food {data['id']}: {resp}")
+        return resp
+
+    def _get_custom_food(self, food_id: int) -> dict:
+        """Fetch a food and refuse anything the user didn't create.
+
+        Re-sending a database food through add_food is untested territory (it
+        might create a private copy or fail), so only source "Custom" -- what
+        get_food reports for user-created foods -- may be edited or retired.
+        """
+        food = self.get_food(food_id)
+        if food.get("source") != "Custom":
+            raise CronometerError(
+                f"Food {food_id} ({food.get('name')!r}) is not a custom food "
+                f"(source={food.get('source')!r}); only custom foods can be edited"
+            )
+        return food
+
+    @staticmethod
+    def _default_measure(food: dict) -> dict | None:
+        measures = food.get("measures") or []
+        for m in measures:
+            if m.get("id") == food.get("defaultMeasureId"):
+                return m
+        return measures[0] if measures else None
+
+    def update_custom_food(
+        self,
+        food_id: int,
+        *,
+        name: str | None = None,
+        calories: float | None = None,
+        protein_g: float | None = None,
+        fat_g: float | None = None,
+        carbs_g: float | None = None,
+        fiber_g: float | None = None,
+        sugar_g: float | None = None,
+        sodium_mg: float | None = None,
+        saturated_fat_g: float | None = None,
+        extra_nutrients: dict[int, float] | None = None,
+        serving_name: str | None = None,
+        serving_grams: float | None = None,
+    ) -> dict:
+        """Edit a user-created custom food in place.
+
+        Only the fields passed (not None) change; everything else is re-sent
+        exactly as the server returned it. Nutrient amounts are per serving --
+        the default measure's weight, or serving_grams when given -- and are
+        normalized to per-100g like create_custom_food. Changing serving_grams
+        alone leaves the stored per-100g values as they are, so the food's
+        per-serving numbers shift with the new weight.
+
+        Returns {"food_id": int, "name": str}.
+        """
+        if extra_nutrients:
+            overlap = set(extra_nutrients) & _RESERVED_CUSTOM_FOOD_NUTRIENT_IDS
+            if overlap:
+                raise ValueError(
+                    f"extra_nutrients overlaps IDs already set by the named "
+                    f"macro args: {sorted(overlap)}. Use the named args for "
+                    f"those instead."
+                )
+
+        food = self._get_custom_food(food_id)
+
+        if name is not None:
+            old_name = food.get("name")
+            food["name"] = name
+            for t in food.get("translations", []):
+                if t.get("name") == old_name:
+                    t["name"] = name
+
+        measure = self._default_measure(food)
+        if measure is not None:
+            if serving_name is not None:
+                measure["name"] = serving_name
+            if serving_grams is not None:
+                measure["value"] = serving_grams
+        grams = (measure or {}).get("value") or 100.0
+        scale = 100.0 / grams if grams > 0 else 1.0
+
+        per_serving = {
+            NUTRIENT_IDS["energy"]: calories,
+            NUTRIENT_IDS["protein"]: protein_g,
+            NUTRIENT_IDS["fat"]: fat_g,
+            NUTRIENT_IDS["carbs"]: carbs_g,
+            NUTRIENT_IDS["fiber"]: fiber_g,
+            NUTRIENT_IDS["sugar"]: sugar_g,
+            NUTRIENT_IDS["sodium"]: sodium_mg,
+            NUTRIENT_IDS["saturated_fat"]: saturated_fat_g,
+        }
+        updates = {
+            nid: round(v * scale, 2) for nid, v in per_serving.items() if v is not None
+        }
+        for nid, v in (extra_nutrients or {}).items():
+            updates[nid] = round(v * scale, 2)
+
+        nutrients = food.setdefault("nutrients", [])
+        by_id = {n["id"]: n for n in nutrients}
+
+        def set_amount(nid: int, amount: float) -> None:
+            entry = by_id.get(nid)
+            if entry is None:
+                entry = {"id": nid, "amount": amount}
+                nutrients.append(entry)
+                by_id[nid] = entry
+            else:
+                entry["amount"] = amount
+
+        for nid, amount in updates.items():
+            set_amount(nid, amount)
+
+        # Derived duplicates the app stores alongside the macros (see
+        # create_custom_food): mirrored protein/fat/carbs and net carbs.
+        for src, mirror in ((203, -203), (204, -204), (205, -205)):
+            if src in updates:
+                set_amount(mirror, updates[src])
+        if NUTRIENT_IDS["carbs"] in updates or NUTRIENT_IDS["fiber"] in updates:
+            carbs = by_id.get(NUTRIENT_IDS["carbs"], {}).get("amount", 0)
+            fiber = by_id.get(NUTRIENT_IDS["fiber"], {}).get("amount", 0)
+            set_amount(NUTRIENT_IDS["net_carbs"], round(max(0, carbs - fiber), 2))
+
+        self._save_custom_food(food)
+        logger.info("Updated custom food %r (id=%d)", food["name"], food_id)
+        return {"food_id": food_id, "name": food["name"]}
+
+    def retire_custom_food(self, food_id: int) -> dict:
+        """Retire (soft-delete) a user-created custom food.
+
+        Sets `retired` on the food and saves it. A retired food drops out of
+        search and the Custom Foods list but stays readable by id and keeps
+        existing diary entries intact. The app's own delete removes the food
+        outright through an endpoint this client doesn't know; retiring is the
+        closest the known API offers, and it is idempotent.
+
+        Returns {"food_id": int, "name": str, "retired": True}.
+        """
+        food = self._get_custom_food(food_id)
+        food["retired"] = True
+        self._save_custom_food(food)
+        logger.info("Retired custom food %r (id=%d)", food.get("name"), food_id)
+        return {"food_id": food_id, "name": food.get("name"), "retired": True}
 
     # ------------------------------------------------------------------
     # Recipe creation

--- a/src/cronometer_api_mcp/server.py
+++ b/src/cronometer_api_mcp/server.py
@@ -610,6 +610,112 @@ def add_custom_food(
         return _err(e)
 
 
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+)
+def update_custom_food(
+    food_id: int,
+    name: str | None = None,
+    calories: float | None = None,
+    protein_g: float | None = None,
+    fat_g: float | None = None,
+    carbs_g: float | None = None,
+    fiber_g: float | None = None,
+    sugar_g: float | None = None,
+    sodium_mg: float | None = None,
+    saturated_fat_g: float | None = None,
+    extra_nutrients: dict[int, float] | None = None,
+    serving_name: str | None = None,
+    serving_grams: float | None = None,
+) -> str:
+    """Edit an existing custom food (one you created) in place.
+
+    Only the arguments you pass change; everything else keeps its current
+    value. Find the food_id with search_foods (source "Custom") or
+    get_food_details. Diary entries that already use the food pick up the
+    new values.
+
+    Nutrient amounts are per serving: the food's default serving, or
+    serving_grams when you pass it. To change the serving weight without
+    re-entering nutrition, pass serving_grams alone; the stored per-100g
+    values stay put, so the per-serving numbers scale with the new weight.
+
+    Args:
+        food_id: ID of the custom food to edit.
+        name: New food name.
+        calories: Calories per serving (kcal).
+        protein_g: Protein per serving (g).
+        fat_g: Fat per serving (g).
+        carbs_g: Carbs per serving (g).
+        fiber_g: Fiber per serving (g).
+        sugar_g: Sugar per serving (g).
+        sodium_mg: Sodium per serving (mg).
+        saturated_fat_g: Saturated fat per serving (g).
+        extra_nutrients: Additional nutrients keyed by Cronometer nutrient ID
+            (from get_daily_nutrition) and valued per serving; must not reuse
+            an ID the named args already cover.
+        serving_name: New name for the default serving.
+        serving_grams: New weight of the default serving in grams.
+    """
+    try:
+        client = _get_client()
+        result = client.update_custom_food(
+            food_id,
+            name=name,
+            calories=calories,
+            protein_g=protein_g,
+            fat_g=fat_g,
+            carbs_g=carbs_g,
+            fiber_g=fiber_g,
+            sugar_g=sugar_g,
+            sodium_mg=sodium_mg,
+            saturated_fat_g=saturated_fat_g,
+            extra_nutrients=extra_nutrients,
+            serving_name=serving_name,
+            serving_grams=serving_grams,
+        )
+        return _ok({"food_id": result["food_id"], "name": result["name"]})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    }
+)
+def delete_custom_food(food_id: int) -> str:
+    """Delete a custom food (one you created) by retiring it.
+
+    The food disappears from search and from the Custom Foods list. Diary
+    entries that already use it are kept, and get_food_details can still read
+    it by ID. Database foods (USDA, NCCDB, CRDB, ...) cannot be deleted.
+
+    Args:
+        food_id: ID of the custom food to delete.
+    """
+    try:
+        client = _get_client()
+        result = client.retire_custom_food(food_id)
+        return _ok(
+            {
+                "food_id": result["food_id"],
+                "name": result["name"],
+                "retired": True,
+            }
+        )
+    except Exception as e:
+        return _err(e)
+
+
 # ------------------------------------------------------------------
 # Recipe creation
 # ------------------------------------------------------------------

--- a/tests/test_custom_food_edit.py
+++ b/tests/test_custom_food_edit.py
@@ -1,0 +1,222 @@
+"""update_custom_food / retire_custom_food.
+
+Both ride on /api/v2/add_food, which upserts: re-sending a food object with
+its existing id edits it in place, and flipping `retired` hides it from search
+and the Custom Foods list (the app's own delete hard-deletes via an endpoint we
+haven't found; retiring is the closest the known API offers).
+"""
+
+from __future__ import annotations
+
+import pytest
+from test_client import make_cold_client
+
+from cronometer_api_mcp.client import CronometerError
+
+FOOD_ID = 81460655
+OK = {"result": "SUCCESS", "id": FOOD_ID}
+
+
+def custom_food(**overrides) -> dict:
+    """A get_food body shaped like the real one for a user-created food.
+
+    Nutrients are per-100g; the default measure is a 50 g serving, so
+    per-serving values are half of what is stored.
+    """
+    food = {
+        "id": FOOD_ID,
+        "name": "Test Food",
+        "source": "Custom",
+        "owner": 42,
+        "retired": False,
+        "category": 0,
+        "labelType": "AMERICAN_2016",
+        "foodTags": [],
+        "barcodes": [],
+        "properties": {},
+        "meal": False,
+        "defaultMeasureId": 900,
+        "measures": [
+            {
+                "id": 900,
+                "name": "serving",
+                "amount": 1,
+                "value": 50,
+                "type": "Atomic",
+                "hidden": False,
+                "derivable": False,
+                "derived": False,
+            }
+        ],
+        "translations": [
+            {"translationId": 1, "name": "Test Food", "languageCode": "en"}
+        ],
+        "nutrients": [
+            {"id": 208, "amount": 200, "type": "PRIMARY"},
+            {"id": 203, "amount": 20, "type": "PRIMARY"},
+            {"id": 204, "amount": 10, "type": "PRIMARY"},
+            {"id": 205, "amount": 40, "type": "PRIMARY"},
+            {"id": 291, "amount": 4, "type": "PRIMARY"},
+            {"id": 269, "amount": 0, "type": "PRIMARY"},
+            {"id": 307, "amount": 0, "type": "PRIMARY"},
+            {"id": 606, "amount": 0, "type": "PRIMARY"},
+            {"id": -203, "amount": 20, "type": "PRIMARY"},
+            {"id": -204, "amount": 10, "type": "PRIMARY"},
+            {"id": -205, "amount": 40, "type": "PRIMARY"},
+            {"id": -221, "amount": 0, "type": "PRIMARY"},
+            {"id": -1205, "amount": 36, "type": "PRIMARY"},
+            {"id": 601, "amount": 30, "type": "PRIMARY"},  # cholesterol (extra)
+        ],
+        # Server-side sync events that ride along on get_food; not food data.
+        "messages": [
+            {"id": 1, "type": "FOOD_CHANGED", "text": '{"id":1,"type":"ADD"}'}
+        ],
+    }
+    food.update(overrides)
+    return food
+
+
+def nutrients_by_id(payload: dict) -> dict[int, float]:
+    return {n["id"]: n["amount"] for n in payload["data"]["nutrients"]}
+
+
+# ---------------------------------------------------------------------------
+# update_custom_food
+# ---------------------------------------------------------------------------
+
+
+def test_update_custom_food_resends_food_with_same_id_and_new_name(tmp_path):
+    """The fetched food goes back to add_food with its id intact, the new name
+    applied to both the name and its translation, and the sync messages
+    stripped."""
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    result = client.update_custom_food(FOOD_ID, name="Renamed")
+
+    get_payload, add_payload = state["payloads"]
+    assert get_payload["id"] == FOOD_ID
+    data = add_payload["data"]
+    assert data["id"] == FOOD_ID
+    assert data["name"] == "Renamed"
+    assert [t["name"] for t in data["translations"]] == ["Renamed"]
+    assert data["retired"] is False
+    assert "messages" not in data
+    assert add_payload["config"] == {"call_version": 1}
+    assert result == {"food_id": FOOD_ID, "name": "Renamed"}
+
+
+def test_update_custom_food_scales_macros_by_default_serving(tmp_path):
+    """Nutrient args are per serving; storage is per-100g, so a 50 g default
+    measure doubles them. Nutrients not passed keep their stored values."""
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    client.update_custom_food(FOOD_ID, calories=150, sodium_mg=30)
+
+    by_id = nutrients_by_id(state["payloads"][1])
+    assert by_id[208] == 300.0  # 150 kcal per 50 g serving
+    assert by_id[307] == 60.0
+    assert by_id[203] == 20  # untouched
+    assert by_id[204] == 10
+
+
+def test_update_custom_food_refreshes_derived_fields(tmp_path):
+    """The app mirrors protein/fat/carbs into -203/-204/-205 and keeps
+    net carbs (-1205) = carbs - fiber; an edit must keep those consistent."""
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    client.update_custom_food(FOOD_ID, protein_g=15, carbs_g=10, fiber_g=4)
+
+    by_id = nutrients_by_id(state["payloads"][1])
+    assert by_id[203] == 30.0
+    assert by_id[-203] == 30.0
+    assert by_id[205] == 20.0
+    assert by_id[-205] == 20.0
+    assert by_id[291] == 8.0
+    assert by_id[-1205] == 12.0  # 20 - 8
+    assert by_id[-204] == 10  # fat untouched
+
+
+def test_update_custom_food_serving_overrides_measure_and_scale(tmp_path):
+    """serving_grams / serving_name edit the default measure, and nutrient
+    args are interpreted against the new serving size."""
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    client.update_custom_food(
+        FOOD_ID, serving_name="1 cup", serving_grams=200, calories=400
+    )
+
+    data = state["payloads"][1]["data"]
+    (measure,) = data["measures"]
+    assert measure["id"] == 900
+    assert measure["name"] == "1 cup"
+    assert measure["value"] == 200
+    assert nutrients_by_id(state["payloads"][1])[208] == 200.0  # 400 per 200 g
+
+
+def test_update_custom_food_extra_nutrients(tmp_path):
+    """extra_nutrients are set (scaled) by id, replacing an existing entry or
+    appending a new one, and may not overlap the named macro args."""
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    client.update_custom_food(FOOD_ID, extra_nutrients={601: 2.5, 430: 10.0})
+
+    by_id = nutrients_by_id(state["payloads"][1])
+    assert by_id[601] == 5.0  # cholesterol, replaced in place
+    assert by_id[430] == 20.0  # vitamin K, appended
+    ids = [n["id"] for n in state["payloads"][1]["data"]["nutrients"]]
+    assert ids.count(601) == 1
+
+    client2, _ = make_cold_client(tmp_path, [custom_food(), OK])
+    with pytest.raises(ValueError):
+        client2.update_custom_food(FOOD_ID, extra_nutrients={204: 1.0})
+
+
+def test_update_custom_food_refuses_database_foods(tmp_path):
+    """Only user-created foods may be edited; a database food is rejected
+    before anything is sent to add_food."""
+    client, state = make_cold_client(
+        tmp_path, [custom_food(source="CRDB", owner=None), OK]
+    )
+
+    with pytest.raises(CronometerError, match="not a custom food"):
+        client.update_custom_food(FOOD_ID, name="Renamed")
+
+    assert len(state["payloads"]) == 1  # only the get_food
+
+
+def test_update_custom_food_raises_when_server_returns_other_id(tmp_path):
+    """add_food answering with a different id means it created a copy instead
+    of editing in place; surface that rather than report success."""
+    client, _ = make_cold_client(
+        tmp_path, [custom_food(), {"result": "SUCCESS", "id": FOOD_ID + 1}]
+    )
+
+    with pytest.raises(CronometerError):
+        client.update_custom_food(FOOD_ID, name="Renamed")
+
+
+# ---------------------------------------------------------------------------
+# retire_custom_food
+# ---------------------------------------------------------------------------
+
+
+def test_retire_custom_food_resends_food_with_retired_flag(tmp_path):
+    client, state = make_cold_client(tmp_path, [custom_food(), OK])
+
+    result = client.retire_custom_food(FOOD_ID)
+
+    data = state["payloads"][1]["data"]
+    assert data["id"] == FOOD_ID
+    assert data["retired"] is True
+    assert data["name"] == "Test Food"
+    assert "messages" not in data
+    assert result == {"food_id": FOOD_ID, "name": "Test Food", "retired": True}
+
+
+def test_retire_custom_food_refuses_database_foods(tmp_path):
+    client, state = make_cold_client(tmp_path, [custom_food(source="USDA"), OK])
+
+    with pytest.raises(CronometerError, match="not a custom food"):
+        client.retire_custom_food(FOOD_ID)
+
+    assert len(state["payloads"]) == 1

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -16,6 +16,7 @@ EXPECTED_TOOLS = {
     "add_food_entry",
     "add_recipe",
     "copy_day",
+    "delete_custom_food",
     "get_biometrics",
     "get_daily_nutrition",
     "get_fasting_history",
@@ -29,6 +30,7 @@ EXPECTED_TOOLS = {
     "mark_day_complete",
     "remove_food_entry",
     "search_foods",
+    "update_custom_food",
 }
 
 
@@ -93,6 +95,7 @@ def test_tool_annotations_survive_schema_coercion():
 
     assert tools["get_food_log"].annotations.read_only_hint is True
     assert tools["add_food_entry"].annotations.read_only_hint is False
+    assert tools["delete_custom_food"].annotations.destructive_hint is True
 
 
 def test_no_client_constructed_at_import():


### PR DESCRIPTION
## Summary

- `update_custom_food` tool: edit a custom food in place (name, per-serving nutrition, `extra_nutrients`, default serving name/weight). Only the arguments passed change; everything else is re-sent as the server returned it.
- `delete_custom_food` tool: retire a custom food so it leaves search and the Custom Foods list. Existing diary entries are kept and `get_food_details` can still read it by id.
- Client methods `update_custom_food()` / `retire_custom_food()`, README rows, tests (`tests/test_custom_food_edit.py`).

Independent of #52.

## How it works

`/api/v2/add_food` upserts. Verified against the live API on a throwaway custom food:

- Re-sending the `get_food` object with its existing `id` (and the `messages` sync events stripped) answers `{"result": "SUCCESS", "id": <same id>}`; the name, energy and translation change, the measure id and untouched nutrients survive.
- Re-sending it with `"retired": true` drops it from `find_food` and from the web app's Custom Foods list, while `get_food` still returns it with `retired: true`.

The app's own delete is a hard delete (afterwards `get_food` answers `doGetFood(): Food … not found`) through an endpoint I couldn't find in the known catalog. Retiring is the closest the API offers and matches what the user sees, so the tool is named `delete_custom_food` and its docstring says what actually happens.

Guards: only foods whose `source` is `"Custom"` are accepted; database foods (`USDA`, `NCCDB:…`, `CRDB`) are refused before anything is written, since re-sending those through `add_food` is untested. A response whose `id` differs from the one sent raises instead of reporting success.

Nutrient handling mirrors `create_custom_food`: per-serving amounts are normalized to per-100g using the default measure's grams (or `serving_grams` when passed), the derived `-203/-204/-205/-1205` entries are kept consistent, and the `extra_nutrients` overlap check is reused. Passing `serving_grams` alone leaves the stored per-100g values as they are (documented in the tool description).

## Test plan

- `uv run pytest`: 63 passed (54 existing + 9 new); `ruff check` / `ruff format --check` clean.
- Live, through the MCP server: `add_custom_food` → `update_custom_food` (rename + `calories=150` on a 50 g serving) → `get_food_details` shows the new name and 300 kcal per 100 g → `delete_custom_food` on an NCCDB food is refused → `delete_custom_food` on the throwaway succeeds → `search_foods` no longer lists it.
