### PR TITLE
Resolve the account timezone before reading the clock

### DIFF
--- a/src/cronometer_api_mcp/client.py
+++ b/src/cronometer_api_mcp/client.py
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://mobile.cronometer.com"
 
-# Fallback timezone used only if the account's timezone can't be resolved from
-# the login response. Matches the value historically assumed by this client.
-_DEFAULT_TIMEZONE = "America/New_York"
+# Only when the zone can't be resolved at all. UTC, not a plausible zone to
+# make fallback more obvious
+_FALLBACK_TIMEZONE = "UTC"
 
 # Optional deploy-time override for the account timezone. When set to a valid
 # IANA zone name it is authoritative over both the login response and any
@@ -206,10 +206,13 @@ class CronometerClient:
             return
         token = data.get("token")
         user_id = data.get("user_id")
-        timezone = data.get("timezone")
-        # Reject caches that lack a stored timezone (pre-timezone schema) so we
-        # re-login once and pick up the account zone rather than guessing.
-        if not isinstance(timezone, str):
+        # Missing key is the pre-timezone schema: re-login to learn the zone.
+        # Explicit null means the account has none, so honour the cache instead
+        # of re-logging in every start against a rate-limited endpoint.
+        if "timezone" not in data:
+            return
+        timezone = data["timezone"]
+        if timezone is not None and not isinstance(timezone, str):
             return
         if isinstance(token, str) and isinstance(user_id, int):
             self._user_id = user_id
@@ -497,38 +500,52 @@ class CronometerClient:
             return None
         return name
 
-    def _resolve_timezone(self, response_tz: str | None) -> str:
-        """Resolve the account timezone by priority.
+    def _resolve_timezone(self, response_tz: str | None) -> str | None:
+        """Env override, else the login response. None when neither is usable.
 
-        1. CRONOMETER_ACCOUNT_TZ env override (authoritative escape hatch).
-        2. The value from the login response (trustworthy now that login()
-           no longer overwrites the account's server-side zone; see #29).
-        3. The historical default.
+        Validates the response: storing an unknown name defers the failure to
+        ``_tzinfo``, where it is no longer attributable to Cronometer.
         """
         env = self._env_timezone()
         if env:
             return env
         if isinstance(response_tz, str) and response_tz:
-            return response_tz
-        return _DEFAULT_TIMEZONE
+            try:
+                ZoneInfo(response_tz)
+                return response_tz
+            except ZoneInfoNotFoundError, ValueError:
+                logger.warning(
+                    "Cronometer reported unknown timezone %r; ignoring", response_tz
+                )
+        return None
 
     def _tzinfo(self) -> ZoneInfo:
-        """Return the account's timezone, falling back to the default.
+        """The account's zone, logging in if that's the only way to learn it.
 
-        Resolved from the login response (or restored session cache). If the
-        stored name is unset or unknown (e.g. a zone missing from the system
-        tzdata), log once and fall back so stamping never hard-fails.
+        Every consumer funnels through here, so this is where the zone has to
+        be guaranteed resolved: callers used to read the clock pre-auth and get
+        the fallback, correcting only once something else triggered login.
+
+        Env override first, so an injected zone needs no network.
         """
-        name = self._timezone or _DEFAULT_TIMEZONE
+        name = self._env_timezone()
+        if not name:
+            self._ensure_auth()
+            name = self._timezone
+        if not name:
+            logger.warning(
+                "No account timezone available; stamping in %s", _FALLBACK_TIMEZONE
+            )
+            return ZoneInfo(_FALLBACK_TIMEZONE)
         try:
             return ZoneInfo(name)
         except ZoneInfoNotFoundError, ValueError:
             logger.warning(
-                "Unknown account timezone %r; falling back to %s",
+                "Unknown account timezone %r; stamping in %s",
                 name,
-                _DEFAULT_TIMEZONE,
+                _FALLBACK_TIMEZONE,
             )
-            return ZoneInfo(_DEFAULT_TIMEZONE)
+            return ZoneInfo(_FALLBACK_TIMEZONE)
 
     def now(self) -> datetime:
         """Current wall-clock time in the account's timezone (aware)."""

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -14,7 +14,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from cronometer_api_mcp.client import CronometerClient
+from cronometer_api_mcp.client import _FALLBACK_TIMEZONE, CronometerClient
 
 
 class FakeResp:
@@ -306,4 +306,179 @@ def test_pre_timezone_cache_is_rejected(tmp_path, monkeypatch):
 def test_unknown_timezone_falls_back(tmp_path):
     """An unresolvable zone name falls back rather than raising."""
     client = _client(tmp_path, "Not/AZone")
-    assert client._tzinfo() == ZoneInfo("America/New_York")
+    assert client._tzinfo() == ZoneInfo(_FALLBACK_TIMEZONE)
+
+
+# ---- cold start: the clock must not be read before the zone is known -------
+#
+# Regression: callers read the clock pre-auth, so the first entry in a fresh
+# container stamped in the fallback zone and later ones were correct -- which
+# read as intermittent drift.
+
+
+def _cold_client(
+    tmp_path: Path, response_tz: str | None
+) -> tuple[CronometerClient, dict]:
+    """An unauthenticated client plus a captured-payload dict.
+
+    Stubs login and add_serving on one fake. Nothing pre-seeds ``_timezone`` --
+    that is the condition under test.
+    """
+    client = CronometerClient(session_path=tmp_path / "session.json")
+    captured: dict = {"logins": 0}
+
+    def fake_post(endpoint, json=None):
+        if endpoint == "/api/v2/login":
+            captured["logins"] += 1
+            body = {"result": "SUCCESS", "id": 123, "sessionKey": "TOKEN"}
+            if response_tz is not None:
+                body["timezone"] = response_tz
+            return FakeResp(body)
+        captured["endpoint"] = endpoint
+        captured["payload"] = json
+        return FakeResp({"result": "SUCCESS", "id": 999})
+
+    client._http.post = fake_post  # type: ignore[method-assign]
+    return client, captured
+
+
+def test_first_add_serving_in_a_cold_client_stamps_in_account_zone(
+    tmp_path, frozen_utc, monkeypatch
+):
+    """The prod regression: 18:01 UTC is 11:01 PDT, not 14:01 Eastern."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    client, captured = _cold_client(tmp_path, "America/Los_Angeles")
+
+    assert client._timezone is None  # nothing resolved yet
+    client.add_serving(food_id=1, measure_id=0, grams=100.0)
+
+    serving = captured["payload"]["serving"]
+    assert serving["time"] == "11:1:30"
+    assert serving["day"] == "2026-7-27"
+    # Lunch; Eastern would have made it Dinner.
+    assert serving["order"] == (2 << 16) | 1
+
+
+def test_cold_client_day_bucketing_uses_account_zone(tmp_path, monkeypatch):
+    """A late-evening PDT entry must not slip a day, as a fallback zone would."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+
+    class LateEvening(_dt.datetime):
+        # 05:30 UTC on the 28th == 22:30 PDT on the 27th.
+        _fixed_utc = _dt.datetime(2026, 7, 28, 5, 30, 0, tzinfo=_dt.UTC)
+
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return cls._fixed_utc.replace(tzinfo=None)
+            return cls._fixed_utc.astimezone(tz)
+
+    monkeypatch.setattr("cronometer_api_mcp.client.datetime", LateEvening)
+    client, captured = _cold_client(tmp_path, "America/Los_Angeles")
+
+    client.add_serving(food_id=1, measure_id=0, grams=100.0)
+
+    assert captured["payload"]["serving"]["day"] == "2026-7-27"
+
+
+def test_env_override_needs_no_login_to_stamp(tmp_path, frozen_utc, monkeypatch):
+    """An injected zone leaves nothing to learn, so no login -- which is what
+    makes a cold container correct on its first entry."""
+    monkeypatch.setenv("CRONOMETER_ACCOUNT_TZ", "America/Los_Angeles")
+    client, captured = _cold_client(tmp_path, "America/New_York")
+
+    assert client._tzinfo() == ZoneInfo("America/Los_Angeles")
+    assert captured["logins"] == 0
+
+
+def test_tzinfo_authenticates_when_zone_is_unknown(tmp_path, frozen_utc, monkeypatch):
+    """Without an override the login response is the only source."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    client, captured = _cold_client(tmp_path, "America/Los_Angeles")
+
+    assert client._tzinfo() == ZoneInfo("America/Los_Angeles")
+    assert captured["logins"] == 1
+
+
+def test_cold_today_uses_account_zone(tmp_path, frozen_utc, monkeypatch):
+    """today() defaults a date for many tools, so it must resolve too."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    client, _ = _cold_client(tmp_path, "America/Los_Angeles")
+
+    assert client.today() == _dt.date(2026, 7, 27)
+
+
+# ---- fallback must not look plausible -------------------------------------
+
+
+def test_missing_response_zone_falls_back_to_utc(tmp_path, frozen_utc, monkeypatch):
+    """No reported zone -> UTC. Eastern was a silent 3h lie for a PDT user."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    client, _ = _cold_client(tmp_path, None)
+
+    assert client._tzinfo() == ZoneInfo("UTC")
+
+
+def test_unresolvable_response_zone_is_rejected_at_the_boundary(
+    tmp_path, frozen_utc, monkeypatch
+):
+    """Rejected where it's still attributable to Cronometer."""
+    monkeypatch.setenv("CRONOMETER_USERNAME", "u@example.com")
+    monkeypatch.setenv("CRONOMETER_PASSWORD", "pw")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    client, _ = _cold_client(tmp_path, "Mars/Olympus_Mons")
+
+    client.login()
+    assert client._timezone is None
+    assert client._tzinfo() == ZoneInfo("UTC")
+
+
+def test_unknown_stored_zone_falls_back_to_utc(tmp_path):
+    """A zone this tzdata build can't construct is our problem, not theirs."""
+    client = _client(tmp_path, "Not/AZone")
+    assert client._tzinfo() == ZoneInfo("UTC")
+
+
+# ---- session cache must not thrash logins for zoneless accounts ------------
+
+
+def test_cache_with_null_timezone_is_reused(tmp_path, monkeypatch):
+    """None is now a legitimate resolved value, persisted as null. Treating it
+    like the legacy schema would re-login on every container start."""
+    import json
+
+    monkeypatch.setenv("CRONOMETER_USERNAME", "")
+    monkeypatch.delenv("CRONOMETER_ACCOUNT_TZ", raising=False)
+    (tmp_path / "session.json").write_text(
+        json.dumps({"username": "", "user_id": 123, "token": "TOKEN", "timezone": None})
+    )
+
+    client = CronometerClient(session_path=tmp_path / "session.json")
+
+    assert client._token == "TOKEN"
+    assert client._timezone is None
+    assert client._tzinfo() == ZoneInfo(_FALLBACK_TIMEZONE)
+
+
+def test_cache_predating_timezone_support_is_still_rejected(tmp_path, monkeypatch):
+    """No timezone key is the legacy schema: re-login to learn the zone."""
+    import json
+
+    monkeypatch.setenv("CRONOMETER_USERNAME", "")
+    (tmp_path / "session.json").write_text(
+        json.dumps({"username": "", "user_id": 123, "token": "TOKEN"})
+    )
+
+    client = CronometerClient(session_path=tmp_path / "session.json")
+
+    assert client._token is None


### PR DESCRIPTION
_tzinfo() read self._timezone while stamping, but on a cold client _ensure_auth() hadn't run yet, so it fell back to Eastern. The first entry in a fresh container stamped +3h for a Pacific user while every later one was correct, which read as intermittent drift. add_serving was the reported case; ~15 other sites default a date the same way.

Resolve inside _tzinfo(), which every consumer funnels through, checking the `CRONOMETER_ACCOUNT_TZ` override first so an injected zone needs no login. Fall back to UTC, not Eastern -- a plausible zone is what let the skew hide. Validate the login response, and accept an explicit null in the session cache so zoneless accounts don't re-login on every start.